### PR TITLE
Add Stripe testing docs

### DIFF
--- a/docs/stripe-testing-best-practices.md
+++ b/docs/stripe-testing-best-practices.md
@@ -1,0 +1,10 @@
+# Stripe Testing Best Practices
+
+Stripe provides special testing resources to help you verify your integration. Always perform your tests in **test mode** using test API keys and tokens.
+
+- Use the [test card numbers](https://stripe.com/docs/testing#international-cards) and test bank account information to simulate different outcomes.
+- Isolate scenarios in [Sandboxes](https://stripe.com/docs/sandboxes) when you need separate environments for teams or partners.
+- Automate recurring flows with [test clocks](https://stripe.com/docs/billing/testing/test-clocks) to advance subscriptions through time.
+- Avoid using real payment method details in your tests. The [Stripe Services Agreement](https://stripe.com/legal/ssa) prohibits testing in live mode with real data.
+
+For more guidance, see the official [Testing](https://stripe.com/docs/testing) docs.

--- a/docs/stripe/api/payment_intents/cancel.md
+++ b/docs/stripe/api/payment_intents/cancel.md
@@ -1,0 +1,19 @@
+# Cancel a PaymentIntent
+
+Use this endpoint to cancel a PaymentIntent before it has been completed. The PaymentIntent must be in a cancellable state such as `requires_payment_method` or `requires_capture`.
+
+```http
+POST /v1/payment_intents/{PAYMENT_INTENT_ID}/cancel
+```
+
+## Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `cancellation_reason` | string | Optional reason for canceling. One of `duplicate`, `fraudulent`, `requested_by_customer`, `abandoned`, `failed_invoice`, or `void_invoice`. |
+
+## Response
+
+Returns the canceled PaymentIntent object if the call succeeds. The object's `status` becomes `canceled` and `canceled_at` is set to a timestamp.
+
+For full details see the [Stripe API documentation](https://stripe.com/docs/api/payment_intents/cancel).

--- a/docs/stripe/connect/testing.md
+++ b/docs/stripe/connect/testing.md
@@ -2,4 +2,6 @@
 
 Before going live, test your Connect integration for account creation, identity verification, and payouts.
 
-Use testing to make sure your *Connect* integration handles different flows correctly. You can use [Sandboxes](https://docs.stripe.com/sandboxes.md) to simulate live mode while taking advantage of Stripe-provided special tokens to use in your tests. See the [payments testing guide](https://docs.stripe.com/testing.md) for more information on testing charges, disputes, and so on.
+Use testing to make sure your *Connect* integration handles different flows correctly. You can use [Sandboxes](https://docs.stripe.com/sandboxes.md) to simulate live mode while taking advantage of Stripe-provided special tokens in your tests. See the [payments testing guide](https://docs.stripe.com/testing.md) for more information on testing charges, disputes, and other flows.
+
+When testing managed accounts, create them in test mode and complete the onboarding flow using test information. To simulate payouts, attach a test bank account or debit card. Review the [Connect testing documentation](https://stripe.com/docs/connect/testing) for the latest steps and supported test tokens.


### PR DESCRIPTION
## Summary
- document recommended best practices for testing Stripe integrations
- expand Connect testing guide text
- describe the `cancel` PaymentIntent API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841adbd048c8328ab8462c8a051a3e6