### PR TITLE
Add SupabaseProvider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,49 @@
 ## Documentation
 
 - [Stripe Testing Best Practices](docs/stripe-testing-best-practices.md)
+
+## SupabaseProvider
+
+`SupabaseProvider` creates a client instance using your project's Supabase
+credentials and exposes it through the `useSupabaseContext` hook. To configure
+the provider you must set the following environment variables in a `.env` file
+or in your deployment settings:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<your project url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your anon key>
+```
+
+For more information on obtaining these values see the [Supabase getting
+started docs](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs).
+
+### Usage
+
+Wrap your application's root layout in `SupabaseProvider` and access the client
+and the active session via `useSupabaseContext`.
+
+```tsx
+// app/layout.tsx
+import { SupabaseProvider } from './providers/SupabaseProvider';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+    return <SupabaseProvider>{children}</SupabaseProvider>;
+}
+```
+
+```tsx
+// Example component
+'use client';
+import { useSupabaseContext } from '@/app/providers/SupabaseProvider';
+
+export default function Example() {
+    const { client, session } = useSupabaseContext();
+
+    const loadProfile = async () => {
+        const { data } = await client.from('profiles').select('*');
+        console.log(session?.user, data);
+    };
+
+    return <button onClick={loadProfile}>Load Profile</button>;
+}
+```


### PR DESCRIPTION
## Summary
- document the SupabaseProvider and environment variables
- show how to access the client and session with `useSupabaseContext`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6841c470bf2883288a8021e919000f82