### PR TITLE
Add SetupIntent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ export default function Example() {
 }
 ```
 
+## SetupIntent Example
+
+Use the `stripe` library with your secret key stored in `STRIPE_SK` to create a
+SetupIntent for an existing customer. The publishable key can be accessed via
+`STRIPE_PK` on the client if needed.
+
+```ts
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SK as string, {
+    apiVersion: '2022-11-15',
+});
+
+export async function createSetupIntent(customerId: string) {
+    return stripe.setupIntents.create({
+        usage: 'off_session',
+        customer: customerId,
+    });
+}
+```
+
 ## Testing
 
 Unit tests use **Jest** with **ts-jest** so TypeScript sources compile during the

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@stripe/stripe-js": "^7.3.1",
         "axios": "^1.5.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "stripe": "^12.18.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.17.0",
@@ -1320,7 +1321,6 @@
       "version": "22.15.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
       "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1849,7 +1849,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5104,7 +5103,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5452,6 +5450,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -5715,7 +5728,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5735,7 +5747,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5752,7 +5763,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5771,7 +5781,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5952,6 +5961,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/supports-color": {
@@ -6168,7 +6190,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@stripe/stripe-js": "^7.3.1",
     "axios": "^1.5.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "stripe": "^12.18.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",
@@ -17,8 +18,8 @@
     "@types/jest": "^29.5.0",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.7",
-    "jest-environment-jsdom": "^29.6.1",
     "jest": "^29.6.1",
+    "jest-environment-jsdom": "^29.6.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },

--- a/services/stripe/setupIntent.ts
+++ b/services/stripe/setupIntent.ts
@@ -1,0 +1,12 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SK as string, {
+    apiVersion: '2022-11-15',
+});
+
+export async function createSetupIntentServerCustomer(customerId: string) {
+    return stripe.setupIntents.create({
+        usage: 'off_session',
+        customer: customerId,
+    });
+}


### PR DESCRIPTION
## Summary
- add SetupIntent example using env vars
- include simple server helper to create a SetupIntent
- add stripe dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68424e33090c832897bfaf59a8b04a5d