### PR TITLE
Add more Stripe API helpers

### DIFF
--- a/services/stripe/__tests__/http.test.ts
+++ b/services/stripe/__tests__/http.test.ts
@@ -1,0 +1,35 @@
+import {
+  createCustomer,
+  createSetupIntent,
+  createPaymentIntent,
+  retrievePaymentIntent,
+  retrieveCustomer,
+  listCustomers,
+  listCharges
+} from '../http'
+
+describe('stripe http api', () => {
+  it('creates and retrieves a payment intent', async () => {
+    const pi = await createPaymentIntent(200, 'usd')
+    expect(pi.id).toMatch(/^pi_/)
+    const fetched = await retrievePaymentIntent(pi.id)
+    expect(fetched.id).toBe(pi.id)
+  }, 30000)
+
+  it('creates and retrieves a customer', async () => {
+    const customer = await createCustomer()
+    const retrieved = await retrieveCustomer(customer.id)
+    expect(retrieved.id).toBe(customer.id)
+  }, 30000)
+
+  it('lists customers', async () => {
+    const res = await listCustomers(1)
+    expect(Array.isArray(res.data)).toBe(true)
+    expect(res.data.length).toBeGreaterThan(0)
+  }, 30000)
+
+  it('lists charges', async () => {
+    const charges = await listCharges(1)
+    expect(Array.isArray(charges.data)).toBe(true)
+  }, 30000)
+})

--- a/services/stripe/http.ts
+++ b/services/stripe/http.ts
@@ -58,3 +58,29 @@ export async function createSetupIntent(customerId: string) {
 export async function listCharges(limit: number = 1) {
   return fetchWithFallback(`/charges?limit=${limit}`)
 }
+
+export async function createPaymentIntent(
+  amount: number,
+  currency: string,
+  customerId?: string
+) {
+  const body = new URLSearchParams({
+    amount: amount.toString(),
+    currency,
+  })
+  if (customerId) body.append('customer', customerId)
+  body.append('payment_method_types[]', 'card')
+  return fetchWithFallback('/payment_intents', { method: 'POST', body })
+}
+
+export async function retrievePaymentIntent(id: string) {
+  return fetchWithFallback(`/payment_intents/${id}`)
+}
+
+export async function retrieveCustomer(id: string) {
+  return fetchWithFallback(`/customers/${id}`)
+}
+
+export async function listCustomers(limit: number = 3) {
+  return fetchWithFallback(`/customers?limit=${limit}`)
+}


### PR DESCRIPTION
## Summary
- extend Stripe HTTP helpers with new endpoints
- add tests covering payment intents, customers, and charges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684267f6865c8328a08eefee30cc5114