### PR TITLE
Add Stripe product/price creation utilities

### DIFF
--- a/services/stripe/__tests__/http.test.ts
+++ b/services/stripe/__tests__/http.test.ts
@@ -12,7 +12,9 @@ import {
   updateCustomer,
   deleteCustomer,
   createEphemeralKey,
-  listPrices
+  listPrices,
+  createProduct,
+  createPrice
 } from '../http'
 
 describe('stripe http api', () => {
@@ -63,6 +65,14 @@ describe('stripe http api', () => {
     const customer = await createCustomer()
     const key = await createEphemeralKey(customer.id)
     expect(key.secret).toBeDefined()
+  }, 30000)
+
+  it('creates a product and price', async () => {
+    const product = await createProduct('Test Product')
+    expect(product.id).toMatch(/^prod_/)
+    const price = await createPrice(1500, 'usd', product.id)
+    expect(price.unit_amount).toBe(1500)
+    expect(price.product).toBe(product.id)
   }, 30000)
 
 })

--- a/services/stripe/http.ts
+++ b/services/stripe/http.ts
@@ -140,6 +140,24 @@ export async function listPrices(limit: number = 1) {
   return fetchWithFallback(`/prices?limit=${limit}`)
 }
 
+export async function createProduct(name: string) {
+  const body = new URLSearchParams({ name })
+  return fetchWithFallback('/products', { method: 'POST', body })
+}
+
+export async function createPrice(
+  unitAmount: number,
+  currency: string,
+  productId: string
+) {
+  const body = new URLSearchParams({
+    unit_amount: unitAmount.toString(),
+    currency,
+    product: productId,
+  })
+  return fetchWithFallback('/prices', { method: 'POST', body })
+}
+
 export async function createEphemeralKey(
   customerId: string,
   stripeVersion: string = '2023-10-16'


### PR DESCRIPTION
## Summary
- support creating Stripe products and prices via HTTP
- test product/price creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842d903c37483289bd6da542b59f083