### PR TITLE
Add basic READMEs for directories

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This folder contains project documentation and integration guides. Notable files include:
+
+- `stripe-integration-guide.md` – overview of the Stripe integration pattern using HTTP requests.
+- `stripe-testing-best-practices.md` – recommendations for validating payment logic in test mode.
+- `stripe/` – a mirror of official Stripe docs for reference.
+
+Additional documents may be added here as the project evolves.

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,7 @@
+# Logs
+
+This directory stores log files generated during development and testing.
+
+- `stripe.log` records HTTP interactions with the Stripe API for troubleshooting.
+
+Log output can be safely deleted between runs.

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,9 @@
+# Services
+
+Reusable service modules for interacting with third-party APIs.
+
+Current modules:
+
+- `stripe/` – helper functions that call Stripe's REST API using `fetch`.
+
+Add new service directories here as integrations expand.

--- a/services/stripe/README.md
+++ b/services/stripe/README.md
@@ -1,0 +1,5 @@
+# Stripe Service
+
+Utility functions that communicate with Stripe via HTTP requests.
+
+The accompanying tests in `__tests__/` validate real API interactions using test keys from `.env`.


### PR DESCRIPTION
## Summary
- document contents of `docs`, `logs`, `services`, and `services/stripe`
- note attempt to initialize `Bioverse-app` submodule failed due to credentials

## Testing
- `npm test` *(fails: cannot find test runner types)*

------
https://chatgpt.com/codex/tasks/task_b_68447843656883289ab5ba7e5d170b16