### PR TITLE
Add Stripe provider helpers

### DIFF
--- a/providers/StripeProvider.tsx
+++ b/providers/StripeProvider.tsx
@@ -1,11 +1,22 @@
 'use client'
 import React, { createContext, useContext, useEffect, useState, PropsWithChildren } from 'react'
-import { createCustomer, createSetupIntent } from '../services/stripe/http'
+import {
+  createCustomer,
+  createSetupIntent,
+  createProduct as apiCreateProduct,
+  createPrice as apiCreatePrice,
+} from '../services/stripe/http'
 
 interface StripeContextType {
   customerId: string | null
   clientSecret: string | null
   error: string | null
+  createProduct: (name: string) => Promise<any>
+  createPrice: (
+    amount: number,
+    currency: string,
+    productId: string,
+  ) => Promise<any>
 }
 
 const StripeContext = createContext<StripeContextType | null>(null)
@@ -14,6 +25,18 @@ export const StripeProvider = ({ children }: PropsWithChildren) => {
   const [customerId, setCustomerId] = useState<string | null>(null)
   const [clientSecret, setClientSecret] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+
+  const createProduct = async (name: string) => {
+    return apiCreateProduct(name)
+  }
+
+  const createPrice = async (
+    amount: number,
+    currency: string,
+    productId: string,
+  ) => {
+    return apiCreatePrice(amount, currency, productId)
+  }
 
   useEffect(() => {
     const createCustomerAndIntent = async () => {
@@ -31,7 +54,15 @@ export const StripeProvider = ({ children }: PropsWithChildren) => {
   }, [])
 
   return (
-    <StripeContext.Provider value={{ customerId, clientSecret, error }}>
+    <StripeContext.Provider
+      value={{
+        customerId,
+        clientSecret,
+        error,
+        createProduct,
+        createPrice,
+      }}
+    >
       {children}
     </StripeContext.Provider>
   )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": false,
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add jest types to TypeScript config
- expose `createProduct` and `createPrice` in `StripeProvider`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68447992f5d08328966f4bfb9ceb4251