### PR TITLE
Add Stripe purchase utilities

### DIFF
--- a/dashboard/Dashboard.tsx
+++ b/dashboard/Dashboard.tsx
@@ -1,0 +1,31 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useStripe } from '../providers/StripeProvider'
+
+export default function Dashboard() {
+  const { listPrices, purchasePrice } = useStripe()
+  const [prices, setPrices] = useState<any[]>([])
+
+  useEffect(() => {
+    listPrices(5).then((res: any) => setPrices(res.data || []))
+  }, [])
+
+  const buy = async (priceId: string) => {
+    const intent = await purchasePrice(priceId)
+    console.log('purchased', intent.id)
+  }
+
+  return (
+    <div>
+      <h2>Prices</h2>
+      <ul>
+        {prices.map((p) => (
+          <li key={p.id}>
+            {p.id} - {(p.unit_amount ?? 0) / 100} {p.currency}
+            <button onClick={() => buy(p.id)}>Buy</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/services/stripe/http.ts
+++ b/services/stripe/http.ts
@@ -224,3 +224,18 @@ export async function createSubscription(
 export async function cancelSubscription(id: string) {
   return fetchWithFallback(`/subscriptions/${id}`, { method: 'DELETE' })
 }
+
+export async function listProducts(limit: number = 3) {
+  return fetchWithFallback(`/products?limit=${limit}`)
+}
+
+export async function confirmPaymentIntent(
+  id: string,
+  paymentMethodId: string,
+) {
+  const body = new URLSearchParams({ payment_method: paymentMethodId })
+  return fetchWithFallback(`/payment_intents/${id}/confirm`, {
+    method: 'POST',
+    body,
+  })
+}


### PR DESCRIPTION
## Summary
- expand Stripe API utilities with `listProducts` and `confirmPaymentIntent`
- provide higher level helpers in `StripeProvider`
- add a simple dashboard example
- test purchase flow by creating product, price and confirming payment

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684480a377608328b1ed7f2caa8347a2