### PR TITLE
Add Stripe purchase utilities

### DIFF
--- a/dashboard/Dashboard.tsx
+++ b/dashboard/Dashboard.tsx
@@ -1,0 +1,31 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useStripe } from '../providers/StripeProvider'
+
+export default function Dashboard() {
+  const { listPrices, purchasePrice } = useStripe()
+  const [prices, setPrices] = useState<any[]>([])
+
+  useEffect(() => {
+    listPrices(5).then((res: any) => setPrices(res.data || []))
+  }, [])
+
+  const buy = async (priceId: string) => {
+    const intent = await purchasePrice(priceId)
+    console.log('purchased', intent.id)
+  }
+
+  return (
+    <div>
+      <h2>Prices</h2>
+      <ul>
+        {prices.map((p) => (
+          <li key={p.id}>
+            {p.id} - {(p.unit_amount ?? 0) / 100} {p.currency}
+            <button onClick={() => buy(p.id)}>Buy</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/docs/stripe-integration-guide.md
+++ b/docs/stripe-integration-guide.md
@@ -87,3 +87,18 @@ curl https://api.stripe.com/v1/payment_intents?limit=3 \
 ```
 
 This helper lists your most recent PaymentIntents for debugging purposes.
+
+### Products and Prices
+
+`StripeProvider` also exposes helpers for creating products, listing prices and performing test purchases. The simplest flow is:
+
+```ts
+const { createProduct, createPrice, listPrices, purchasePrice } = useStripe();
+
+const product = await createProduct('Example');
+const price = await createPrice(500, 'usd', product.id);
+const prices = await listPrices(1);
+await purchasePrice(prices.data[0].id);
+```
+
+All purchases use test card tokens like `tok_visa` behind the scenes so no real charges occur.

--- a/providers/README.md
+++ b/providers/README.md
@@ -1,11 +1,11 @@
 # StripeProvider
 
-This provider initializes Stripe on the client and exposes helper functions for common payment tasks. Use the `useStripeContext` hook to access these utilities.
+`StripeProvider` talks directly to the Stripe REST API using the secret key from `.env`. The accompanying hook `useStripe` exposes helper functions for creating customers, products, and mock payments while in test mode.
 
 
 ## Usage
 
-Wrap your root layout in `StripeProvider` and access the context with the `useStripeContext` hook.
+Wrap your root layout in `StripeProvider` and access the helper functions with the `useStripe` hook.
 
 ```tsx
 // app/layout.tsx
@@ -19,26 +19,29 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 ```tsx
 // Example component
 'use client';
-import { useStripeContext } from '@/app/providers/StripeProvider';
+import { useStripe } from '../providers/StripeProvider';
 
-export default function PaymentButton({ customerId }: { customerId: string }) {
-    const { createSetupIntentForCustomer } = useStripeContext();
+export default function PaymentButton() {
+    const { listPrices, purchasePrice } = useStripe();
 
     const handleClick = async () => {
-        await createSetupIntentForCustomer(customerId);
+        const prices = await listPrices(3);
+        await purchasePrice(prices.data[0].id);
     };
 
-    return <button onClick={handleClick}>Create Setup Intent</button>;
+    return <button onClick={handleClick}>Purchase First Price</button>;
 }
 ```
 
 
 ## Provided Functions
 
-- `createSetupIntentForCustomer(customerId)` – create a Setup Intent for a Stripe customer.
-- `updateCustomerDefaultPaymentMethod(customerId)` – update a customer's default payment method via `/api/stripe/payment-method/default`.
-- `updateSubscriptionPaymentMethod(customerId, subscriptionId)` – update a subscription's payment method via `/api/stripe/payment-method/subscription`.
-- `startCheckoutSession(options)` – create a Checkout Session via HTTP and redirect the customer to `session.url` from the response.
-- `listPaymentIntents(limit)` – fetch recent PaymentIntents for debugging.
+`useStripe()` exposes several helpers:
 
-Wrap your application with `StripeProvider` to ensure Stripe is loaded before any payment interactions.
+- `createProduct(name)` – create a Product object in Stripe.
+- `createPrice(amount, currency, productId)` – create a Price for a product.
+- `listProducts(limit)` – list existing products.
+- `listPrices(limit)` – list prices.
+- `purchasePrice(priceId)` – perform a mock purchase using test card tokens.
+
+Wrap your application with `StripeProvider` to ensure the customer and setup intent are created before calling these helpers.

--- a/services/stripe/http.ts
+++ b/services/stripe/http.ts
@@ -224,3 +224,18 @@ export async function createSubscription(
 export async function cancelSubscription(id: string) {
   return fetchWithFallback(`/subscriptions/${id}`, { method: 'DELETE' })
 }
+
+export async function listProducts(limit: number = 3) {
+  return fetchWithFallback(`/products?limit=${limit}`)
+}
+
+export async function confirmPaymentIntent(
+  id: string,
+  paymentMethodId: string,
+) {
+  const body = new URLSearchParams({ payment_method: paymentMethodId })
+  return fetchWithFallback(`/payment_intents/${id}/confirm`, {
+    method: 'POST',
+    body,
+  })
+}


### PR DESCRIPTION
## Summary
- expand Stripe API utilities with `listProducts` and `confirmPaymentIntent`
- provide higher level helpers in `StripeProvider`
- add a simple dashboard example
- test purchase flow by creating product, price and confirming payment
- document usage of the new helpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684480a377608328b1ed7f2caa8347a2