### PR TITLE
Expand stripe provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Stripe Testing Best Practices](docs/stripe-testing-best-practices.md)
 - [Stripe Integration Guide](docs/stripe-integration-guide.md)
 - [Dashboard Guide](docs/dashboard-guide.md)
+- [Stripe API Reference](docs/stripe)
 
 ## SupabaseProvider
 

--- a/providers/README.md
+++ b/providers/README.md
@@ -43,5 +43,9 @@ export default function PaymentButton() {
 - `listProducts(limit)` – list existing products.
 - `listPrices(limit)` – list prices.
 - `purchasePrice(priceId)` – perform a mock purchase using test card tokens.
+- `listAllPaymentIntents()` – auto-paginate through all payment intents.
+- `applyCustomerBalance(id)` – apply a customer's balance to a payment intent.
+- `incrementAuthorization(id, amount)` – increase an authorized amount.
+- `verifyMicrodeposits(id, amounts)` – verify bank account microdeposits.
 
 Wrap your application with `StripeProvider` to ensure the customer and setup intent are created before calling these helpers.

--- a/providers/StripeProvider.tsx
+++ b/providers/StripeProvider.tsx
@@ -21,6 +21,10 @@ import {
   createEphemeralKey as apiCreateEphemeralKey,
   listPaymentIntents as apiListPaymentIntents,
   listCharges as apiListCharges,
+  applyCustomerBalance as apiApplyCustomerBalance,
+  incrementAuthorization as apiIncrementAuthorization,
+  verifyMicrodeposits as apiVerifyMicrodeposits,
+  listAllPaymentIntents as apiListAllPaymentIntents,
 } from '../services/stripe/http'
 
 interface StripeContextType {
@@ -47,8 +51,13 @@ interface StripeContextType {
   updatePaymentIntent: (
     id: string,
     params: Record<string, string>,
+    metadata?: Record<string, string>,
   ) => Promise<any>
   searchPaymentIntents: (query: string, limit?: number) => Promise<any>
+  applyCustomerBalance: (id: string) => Promise<any>
+  incrementAuthorization: (id: string, amount: number) => Promise<any>
+  verifyMicrodeposits: (id: string, amounts: [number, number]) => Promise<any>
+  listAllPaymentIntents: () => Promise<any[]>
 }
 
 const StripeContext = createContext<StripeContextType | null>(null)
@@ -112,6 +121,10 @@ export const StripeProvider = ({ children }: PropsWithChildren) => {
     return apiListPaymentIntents(limit)
   }
 
+  const listAllPaymentIntents = async () => {
+    return apiListAllPaymentIntents()
+  }
+
   const listCharges = async (limit?: number) => {
     return apiListCharges(limit)
   }
@@ -127,12 +140,28 @@ export const StripeProvider = ({ children }: PropsWithChildren) => {
   const updatePaymentIntent = async (
     id: string,
     params: Record<string, string>,
+    metadata?: Record<string, string>,
   ) => {
-    return apiUpdatePaymentIntent(id, params)
+    return apiUpdatePaymentIntent(id, params, metadata)
   }
 
   const searchPaymentIntents = async (query: string, limit?: number) => {
     return apiSearchPaymentIntents(query, limit)
+  }
+
+  const applyCustomerBalance = async (id: string) => {
+    return apiApplyCustomerBalance(id)
+  }
+
+  const incrementAuthorization = async (id: string, amount: number) => {
+    return apiIncrementAuthorization(id, amount)
+  }
+
+  const verifyMicrodeposits = async (
+    id: string,
+    amounts: [number, number],
+  ) => {
+    return apiVerifyMicrodeposits(id, amounts)
   }
 
   useEffect(() => {
@@ -165,11 +194,15 @@ export const StripeProvider = ({ children }: PropsWithChildren) => {
         cancelSubscription,
         createEphemeralKey,
         listPaymentIntents,
+        listAllPaymentIntents,
         listCharges,
         capturePaymentIntent,
         cancelPaymentIntent,
         updatePaymentIntent,
         searchPaymentIntents,
+        applyCustomerBalance,
+        incrementAuthorization,
+        verifyMicrodeposits,
       }}
     >
       {children}

--- a/services/stripe/__tests__/http.test.ts
+++ b/services/stripe/__tests__/http.test.ts
@@ -21,7 +21,10 @@ import {
   createProduct,
   createPrice,
   retrieveProduct,
-  retrievePrice
+  retrievePrice,
+  listAllPaymentIntents,
+  applyCustomerBalance,
+  incrementAuthorization,
 } from '../http'
 
 describe('stripe http api', () => {
@@ -114,6 +117,17 @@ describe('stripe http api', () => {
     expect(fetchedPrice.currency).toBe('usd')
     expect(fetchedPrice.product).toBe(product.id)
 
+  }, 30000)
+
+  it('auto paginates payment intents', async () => {
+    const all = await listAllPaymentIntents()
+    expect(Array.isArray(all)).toBe(true)
+  }, 30000)
+
+  it('handles advanced payment intent actions', async () => {
+    const pi = await createPaymentIntent(400, 'usd')
+    await expect(applyCustomerBalance(pi.id)).rejects.toThrow()
+    await expect(incrementAuthorization(pi.id, 100)).rejects.toThrow()
   }, 30000)
 
 })


### PR DESCRIPTION
## Summary
- improve Stripe HTTP helper with metadata and query support
- add advanced endpoints for payment intents
- expose new helpers from StripeProvider and document them
- extend Stripe tests for advanced features

## Testing
- `npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68448a8102bc8328ad135c045413307c