### PR TITLE
Add metadata and expand support to Stripe helpers

### DIFF
--- a/services/stripe/__tests__/http.test.ts
+++ b/services/stripe/__tests__/http.test.ts
@@ -29,16 +29,24 @@ import {
 
 describe('stripe http api', () => {
   it('creates and retrieves a payment intent', async () => {
-    const pi = await createPaymentIntent(200, 'usd')
+    const customer = await createCustomer({ test: 'pi' })
+    const pi = await createPaymentIntent(200, 'usd', customer.id, { order: '123' }, ['customer'])
     expect(pi.id).toMatch(/^pi_/)
-    const fetched = await retrievePaymentIntent(pi.id)
+    expect(pi.metadata.order).toBe('123')
+    expect(typeof pi.customer).toBe('object')
+    const fetched = await retrievePaymentIntent(pi.id, ['customer'])
     expect(fetched.id).toBe(pi.id)
+    expect(fetched.metadata.order).toBe('123')
+    expect(fetched.customer.id).toBe(customer.id)
   }, 30000)
 
   it('creates and retrieves a customer', async () => {
-    const customer = await createCustomer()
-    const retrieved = await retrieveCustomer(customer.id)
+    const customer = await createCustomer({ tier: 'gold' })
+    expect(customer.metadata.tier).toBe('gold')
+    const retrieved = await retrieveCustomer(customer.id, ['tax_ids'])
     expect(retrieved.id).toBe(customer.id)
+    expect(retrieved.metadata.tier).toBe('gold')
+    expect(retrieved.tax_ids).toBeDefined()
   }, 30000)
 
   it('lists customers', async () => {


### PR DESCRIPTION
## Summary
- allow metadata and expand options when creating/retrieving Stripe objects
- log request bodies for extra visibility
- verify new metadata and expand behaviour in tests

## Testing
- `npm test` *(fails: The PaymentMethod provided is not allowed; some tests timeout)*

------
https://chatgpt.com/codex/tasks/task_b_6844951b681483288857108649d52bf1