### PR TITLE
Add Stripe integration docs

### DIFF
--- a/docs/stripe-integration-guide.md
+++ b/docs/stripe-integration-guide.md
@@ -1,0 +1,50 @@
+# Stripe Integration Guide
+
+This project integrates directly with the Stripe API. All requests use the secret key stored in the `STRIPE_SK` environment variable and fall back to `curl` when a standard fetch fails.
+
+## Configuring API keys
+
+Create a `.env` file in the project root with the test keys from your Stripe dashboard:
+
+```bash
+STRIPE_PK=pk_test_...
+STRIPE_SK=sk_test_...
+```
+
+Use the corresponding live keys (`pk_live_`/`sk_live_`) when deploying to production.
+
+## Basic request pattern
+
+Every helper in `services/stripe/http.ts` logs the request, calls Stripe using `fetch`, and automatically retries using `curl` if the network request fails. This approach ensures reliability even without Node fetch network access.
+
+## Example endpoints
+
+### Create a SetupIntent
+```bash
+curl https://api.stripe.com/v1/setup_intents \
+  -u $STRIPE_SK: \
+  -d customer=cus_123 \
+  -d usage=off_session
+```
+
+### Retrieve a customer
+```bash
+curl https://api.stripe.com/v1/customers/cus_123 -u $STRIPE_SK:
+```
+
+### Create a product and price
+```bash
+curl https://api.stripe.com/v1/products -u $STRIPE_SK: -d name="Demo"
+
+curl https://api.stripe.com/v1/prices \
+  -u $STRIPE_SK: \
+  -d unit_amount=500 \
+  -d currency=usd \
+  -d product=prod_123
+```
+
+## Switching modes
+
+Using test keys keeps all operations in *test mode*. Replace them with live keys only when you intend to process real charges. Never expose your secret key in client-side code.
+
+For additional testing advice see [Stripe Testing Best Practices](./stripe-testing-best-practices.md).

--- a/docs/stripe-testing-best-practices.md
+++ b/docs/stripe-testing-best-practices.md
@@ -1,0 +1,68 @@
+# Stripe Testing Best Practices
+
+Use Stripe's **test mode** to simulate real payment flows without charging real cards. The test keys defined in `.env`—`STRIPE_PK` and `STRIPE_SK`—should be used for all development and automated tests.
+
+## Test mode vs live mode
+
+- Keys beginning with `pk_test_` and `sk_test_` operate in *test mode*.
+- Keys beginning with `pk_live_` and `sk_live_` operate in *live mode*.
+- Never commit your live secret key to version control.
+
+Switch keys in your environment when you are ready to process live transactions.
+
+## Common curl examples
+
+### Create a customer
+```bash
+curl https://api.stripe.com/v1/customers \
+  -u $STRIPE_SK: \
+  -d email="test@example.com" \
+  -d name="Test User"
+```
+
+### Create a product
+```bash
+curl https://api.stripe.com/v1/products \
+  -u $STRIPE_SK: \
+  -d name="Demo Product"
+```
+
+### Create a price
+```bash
+curl https://api.stripe.com/v1/prices \
+  -u $STRIPE_SK: \
+  -d unit_amount=1000 \
+  -d currency=usd \
+  -d product=prod_123
+```
+
+### Create a payment intent
+```bash
+curl https://api.stripe.com/v1/payment_intents \
+  -u $STRIPE_SK: \
+  -d amount=1000 \
+  -d currency=usd \
+  -d customer=cus_123
+```
+
+### Create a subscription
+```bash
+curl https://api.stripe.com/v1/subscriptions \
+  -u $STRIPE_SK: \
+  -d customer=cus_123 \
+  -d items[0][price]=price_123 \
+  -d default_payment_method=pm_123
+```
+
+## Test tokens
+
+Use the token `tok_visa` for successful card payments in test mode. Review the [Stripe testing docs](stripe/testing.md) for additional tokens and scenarios.
+
+## Cleanup example
+
+Delete any test customer when finished:
+```bash
+curl https://api.stripe.com/v1/customers/cus_123 \
+  -u $STRIPE_SK: \
+  -X DELETE
+```


### PR DESCRIPTION
## Summary
- document Stripe testing best practices
- add a Stripe integration guide with curl examples

## Testing
- `npm test --silent` *(fails: 6 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68449511dad08328844572bc87833eec