### PR TITLE
Expand Stripe coverage

### DIFF
--- a/docs/stripe/examples.md
+++ b/docs/stripe/examples.md
@@ -240,3 +240,36 @@ curl https://api.stripe.com/v1/payment_intents/pi_123/verify_microdeposits \
 curl "https://api.stripe.com/v1/payment_intents?limit=100" \
   -u "$STRIPE_SK:"
 ```
+
+## Accounts and Payouts
+
+### Retrieve Account
+```bash
+curl https://api.stripe.com/v1/account \
+  -u "$STRIPE_SK:"
+```
+
+### List Payouts
+```bash
+curl "https://api.stripe.com/v1/payouts?limit=1" \
+  -u "$STRIPE_SK:"
+```
+
+### List Disputes
+```bash
+curl "https://api.stripe.com/v1/disputes?limit=1" \
+  -u "$STRIPE_SK:"
+```
+
+### List Reviews
+```bash
+curl "https://api.stripe.com/v1/reviews?limit=1" \
+  -u "$STRIPE_SK:"
+```
+
+### List Application Fees
+```bash
+curl "https://api.stripe.com/v1/application_fees?limit=1" \
+  -u "$STRIPE_SK:"
+```
+

--- a/services/stripe/__tests__/http.test.ts
+++ b/services/stripe/__tests__/http.test.ts
@@ -37,6 +37,11 @@ import {
   createWebhookEndpoint,
   retrieveWebhookEndpoint,
   deleteWebhookEndpoint,
+  retrieveAccount,
+  listPayouts,
+  listDisputes,
+  listReviews,
+  listApplicationFees,
 } from '../http'
 
 jest.setTimeout(120000)
@@ -188,6 +193,32 @@ describe('stripe http api', () => {
     expect(fetched.id).toBe(webhook.id)
     const del = await deleteWebhookEndpoint(webhook.id)
     expect(del.deleted).toBe(true)
+  }, 30000)
+
+  it('retrieves account information', async () => {
+    const account = await retrieveAccount()
+    expect(account.id).toMatch(/^acct_/)
+    expect(account.object).toBe('account')
+  }, 30000)
+
+  it('lists payouts', async () => {
+    const payouts = await listPayouts(1)
+    expect(Array.isArray(payouts.data)).toBe(true)
+  }, 30000)
+
+  it('lists disputes', async () => {
+    const disputes = await listDisputes(1)
+    expect(Array.isArray(disputes.data)).toBe(true)
+  }, 30000)
+
+  it('lists reviews', async () => {
+    const reviews = await listReviews(1)
+    expect(Array.isArray(reviews.data)).toBe(true)
+  }, 30000)
+
+  it('lists application fees', async () => {
+    const fees = await listApplicationFees(1)
+    expect(Array.isArray(fees.data)).toBe(true)
   }, 30000)
 
 })


### PR DESCRIPTION
## Summary
- add examples for account and payout endpoints
- test additional Stripe endpoints for account, payouts, disputes, reviews, and application fees

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68449e324e0483288fe9de38da85be3c