### PR TITLE
Extend Stripe API support and secure provider

### DIFF
--- a/providers/README.md
+++ b/providers/README.md
@@ -1,11 +1,11 @@
 # StripeProvider
 
-`StripeProvider` talks directly to the Stripe REST API using the secret key from `.env`. The accompanying hook `useStripe` exposes helper functions for creating customers, products, and mock payments while in test mode.
+`StripeProvider` talks directly to the Stripe REST API using the secret key from `.env`. **It is a server component** so the secret key never reaches the browser. The accompanying hook `useStripe` can be consumed from other server components to access helper functions for creating customers, products and mock payments while in test mode.
 
 
 ## Usage
 
-Wrap your root layout in `StripeProvider` and access the helper functions with the `useStripe` hook.
+Wrap your root layout in `StripeProvider` (server component) and access the helper functions with the `useStripe` hook from other server components. Client components should call API routes instead of using the context directly.
 
 ```tsx
 // app/layout.tsx
@@ -44,6 +44,7 @@ export default function PaymentButton() {
 - `listPrices(limit)` – list prices.
 - `purchasePrice(priceId)` – perform a mock purchase using test card tokens.
 - `listAllPaymentIntents()` – auto-paginate through all payment intents.
+- `listAllCharges()` – auto-paginate through all charges.
 - `applyCustomerBalance(id)` – apply a customer's balance to a payment intent.
 - `incrementAuthorization(id, amount)` – increase an authorized amount.
 - `verifyMicrodeposits(id, amounts)` – verify bank account microdeposits.

--- a/providers/__tests__/StripeProvider.test.tsx
+++ b/providers/__tests__/StripeProvider.test.tsx
@@ -18,6 +18,7 @@ import {
   applyCustomerBalance,
   incrementAuthorization,
   listAllPaymentIntents,
+  listAllCharges,
 } from '../../services/stripe/http'
 import { readFileSync } from 'fs'
 
@@ -106,4 +107,19 @@ describe('StripeProvider', () => {
     await expect(applyCustomerBalance(pi.id)).rejects.toThrow()
     await expect(incrementAuthorization(pi.id, 50)).rejects.toThrow()
   }, 30000)
+
+  it('auto-paginates charges', async () => {
+    const all = await listAllCharges(5)
+    expect(Array.isArray(all)).toBe(true)
+  }, 60000)
+
+  it('throws when using test key in production', async () => {
+    const origEnv = process.env.NODE_ENV
+    const origKey = process.env.STRIPE_SK
+    process.env.NODE_ENV = 'production'
+    process.env.STRIPE_SK = 'sk_test_bad'
+    await expect(createCustomer()).rejects.toThrow('STRIPE_SK must be a live key in production')
+    process.env.NODE_ENV = origEnv
+    process.env.STRIPE_SK = origKey
+  })
 })


### PR DESCRIPTION
## Summary
- enforce production secret key check in Stripe HTTP client
- add pagination helper `listAllCharges`
- convert StripeProvider to a server component
- expose new `listAllCharges` method via context
- document server component usage
- test new helper and production key check

## Testing
- `npm test` *(fails: unable to complete due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6844b0df7b848328bc50323564637fe2