### PR TITLE
Improve server-side safeguards for StripeProvider

### DIFF
--- a/providers/README.md
+++ b/providers/README.md
@@ -1,7 +1,7 @@
 # StripeProvider
 
 
-`StripeProvider` talks directly to the Stripe REST API using the secret key from `.env`. **It is a server component** so the secret key never reaches the browser. The provider verifies it is executed server-side and caches the initial customer/setup intent so repeated renders do not create duplicates. The accompanying hook `useStripe` can be consumed from other server components to access helper functions for creating customers, products and mock payments while in test mode.
+`StripeProvider` talks directly to the Stripe REST API using the secret key from `.env`. **It is a server component** so the secret key never reaches the browser. When invoked it ensures the code is running in a Node.js environment (and not the Edge runtime) and that `STRIPE_SK` is present. In production, `STRIPE_SK` must be a live key. The provider caches the initial customer/setup intent so repeated renders do not create duplicates. The accompanying hook `useStripe` can be consumed from other server components to access helper functions for creating customers, products and mock payments while in test mode.
 
 
 

--- a/providers/StripeProvider.tsx
+++ b/providers/StripeProvider.tsx
@@ -93,6 +93,18 @@ export async function StripeProvider({ children }: PropsWithChildren) {
     throw new Error('StripeProvider can only be used on the server')
   }
 
+  if ((globalThis as any).EdgeRuntime) {
+    throw new Error('StripeProvider cannot run in the edge runtime')
+  }
+
+  const sk = process.env.STRIPE_SK
+  if (!sk) {
+    throw new Error('STRIPE_SK not set')
+  }
+  if (process.env.NODE_ENV === 'production' && sk.startsWith('sk_test')) {
+    throw new Error('STRIPE_SK must be a live key in production')
+  }
+
   let customerId: string | null = null
   let clientSecret: string | null = null
   let error: string | null = null

--- a/providers/__tests__/StripeProvider.test.tsx
+++ b/providers/__tests__/StripeProvider.test.tsx
@@ -42,6 +42,19 @@ describe('StripeProvider', () => {
     process.env.STRIPE_SK = orig
   })
 
+  it('fails to initialize StripeProvider without STRIPE_SK', async () => {
+    const { StripeProvider } = await import('../StripeProvider')
+    const orig = process.env.STRIPE_SK
+    const origWindow = (global as any).window
+    delete (global as any).window
+    delete process.env.STRIPE_SK
+    await expect(
+      StripeProvider({ children: React.createElement('div') })
+    ).rejects.toThrow('STRIPE_SK not set')
+    process.env.STRIPE_SK = orig
+    if (origWindow !== undefined) (global as any).window = origWindow
+  })
+
   it('creates a product, price and completes a test payment', async () => {
     const customer = await createCustomer()
     const product = await createProduct('Test Prod')
@@ -122,6 +135,22 @@ describe('StripeProvider', () => {
     await expect(createCustomer()).rejects.toThrow('STRIPE_SK must be a live key in production')
     process.env.NODE_ENV = origEnv
     process.env.STRIPE_SK = origKey
+  })
+
+  it('throws when initializing StripeProvider with a test key in production', async () => {
+    const { StripeProvider } = await import('../StripeProvider')
+    const origEnv = process.env.NODE_ENV
+    const origKey = process.env.STRIPE_SK
+    const origWindow = (global as any).window
+    delete (global as any).window
+    process.env.NODE_ENV = 'production'
+    process.env.STRIPE_SK = 'sk_test_bad'
+    await expect(
+      StripeProvider({ children: React.createElement('div') })
+    ).rejects.toThrow('STRIPE_SK must be a live key in production')
+    process.env.NODE_ENV = origEnv
+    process.env.STRIPE_SK = origKey
+    if (origWindow !== undefined) (global as any).window = origWindow
   })
 
 


### PR DESCRIPTION
## Summary
- add runtime checks in `StripeProvider` to ensure Node environment and valid Stripe key
- document new checks in provider README
- extend tests to cover missing key and invalid key scenarios for `StripeProvider`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844b6a70bdc8328912f8d5c77f752e2