### PR TITLE
Add AGENTS guidelines for directories

### DIFF
--- a/.audit-history/AGENTS.md
+++ b/.audit-history/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Audit History
+
+This directory stores historical audit artifacts such as call graphs and migration plans. Treat these files as read-only. If you run `npm run audit` to generate new reports, create a new date-stamped folder here. Do not modify or delete existing audit entries without coordinating with the team.

--- a/.vscode/AGENTS.md
+++ b/.vscode/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – VS Code Settings
+
+This folder holds shared VS Code configuration. Keep extension recommendations minimal and avoid committing machine-specific paths or secrets. The `denoland.vscode-deno` extension is required for Deno linting and formatting. Adjust local preferences in `settings.json` but ensure they remain broadly applicable to all contributors.

--- a/dashboard/AGENTS.md
+++ b/dashboard/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Dashboard
+
+The dashboard contains example React components that interact with the providers. All components should be written in TypeScript/TSX and may use the `'use client'` directive when necessary. Import hooks like `useStripe` from `../providers` rather than duplicating API calls. Keep the dashboard simple and never commit production secrets.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Docs
+
+All project documentation resides in this directory. Write new guides in Markdown and keep them clear and concise. Run `npm run check:links` before committing to validate external links. The `stripe/` subfolder mirrors official Stripe documentation and should only be updated for formatting fixes or link maintenance.

--- a/docs/stripe/AGENTS.md
+++ b/docs/stripe/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Stripe Docs
+
+This folder contains portions of the official Stripe documentation for quick reference. Avoid rewriting the original content. If you need to annotate or extend these docs, place new Markdown files elsewhere in `docs/` and link to them here.

--- a/logs/AGENTS.md
+++ b/logs/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Logs
+
+Development logs live in this directory. Example log files may be committed for reference, but most log output should be cleaned up before committing. It is safe to delete log files between runs.

--- a/providers/AGENTS.md
+++ b/providers/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Providers
+
+Provider components offer React contexts for external services like Stripe and Supabase. They must run as server components and must not expose secret keys to the browser. Keep accompanying tests in the `__tests__/` folder. Document any required environment variables in the README when adding new providers.

--- a/providers/__tests__/AGENTS.md
+++ b/providers/__tests__/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Provider Tests
+
+Tests in this directory use Jest along with `@testing-library/react` for React components. Use `jest.mock` to stub network requests. Run `npm test` after making changes.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Scripts
+
+Development scripts live here. Write them in TypeScript and execute via `ts-node`. The audit tooling is located in `scripts/audit`. Document any new scripts with usage instructions in a README.

--- a/scripts/audit/AGENTS.md
+++ b/scripts/audit/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Audit Scripts
+
+Scripts in this folder generate code audit reports, call graphs and link checks. Run `npm run audit` to produce a new report in `.audit-history`. Avoid committing large intermediate files outside of that directory and keep dependencies minimal.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – API Server
+
+This directory houses a lightweight Express server used by demos and tests. Route handlers should be async and minimal. Start it locally with `npm start`. When writing tests, mock external services rather than calling them directly.

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Services
+
+Reusable modules for interacting with external APIs. Each service lives in its own subdirectory. Service functions should wrap network requests and include basic error handling. Provide unit tests for every service.

--- a/services/stripe/AGENTS.md
+++ b/services/stripe/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Stripe Service
+
+HTTP helpers for talking to Stripe. Secrets should come from `.env` and never be committed. Tests live under `__tests__/`. Run `npm test` before committing.

--- a/services/stripe/__tests__/AGENTS.md
+++ b/services/stripe/__tests__/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Stripe Service Tests
+
+Tests in this directory validate the Stripe service. Prefer mocking network calls to hitting the real API. Execute `npm test` to run them.

--- a/services/supabase/AGENTS.md
+++ b/services/supabase/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Supabase Service
+
+Wrapper functions for Supabase REST calls. Configuration is read from environment variables such as `SUPABASE_URL` and `SUPABASE_SERVICE_KEY`. Keep this module framework agnostic and ensure it has tests.

--- a/supabase/AGENTS.md
+++ b/supabase/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Supabase Configuration
+
+Configuration files for the local Supabase stack. Avoid committing secret keys. When editing `config.toml` or seed scripts, document the change in this folder's README. Use the Supabase CLI for local development.

--- a/utils/AGENTS.md
+++ b/utils/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Utilities
+
+Utility code lives under this directory. Legacy helpers remain in `unvalidatedUtils/` and are being migrated to `utils/modular/` per the root AGENTS playbook. New utilities must be typed, tested and documented. Avoid adding code to `unvalidatedUtils/` except when migrating.

--- a/utils/unvalidatedUtils/AGENTS.md
+++ b/utils/unvalidatedUtils/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – Legacy Utilities
+
+These modules are unvalidated legacy code slated for migration. Do not modify them directly unless you are refactoring into the new modular utility system. Follow the root AGENTS migration plan for guidance.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` files to each top-level and key subdirectory
- document purpose and guidelines for providers, services, scripts, and more

## Testing
- `CI=true npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_6845cf1a30908328b8115f795e76741d