### PR TITLE
Add OpenAI provider and service

### DIFF
--- a/providers/OpenAIProvider.tsx
+++ b/providers/OpenAIProvider.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react'
+import { chatCompletion, ChatMessage } from '../services/openai/http'
+
+interface OpenAIContextType {
+  generateChat: (messages: ChatMessage[], model?: string) => Promise<any>
+}
+
+const OpenAIContext = createContext<OpenAIContextType | null>(null)
+
+export function OpenAIProvider({ children }: PropsWithChildren) {
+  if (typeof window !== 'undefined') {
+    throw new Error('OpenAIProvider can only be used on the server')
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY not set')
+  }
+
+  const generateChat = (messages: ChatMessage[], model?: string) =>
+    chatCompletion(messages, model)
+
+  return (
+    <OpenAIContext.Provider value={{ generateChat }}>
+      {children}
+    </OpenAIContext.Provider>
+  )
+}
+
+export const useOpenAI = () => {
+  const context = useContext(OpenAIContext)
+  if (!context) throw new Error('useOpenAI must be used within OpenAIProvider')
+  return context
+}

--- a/providers/README.md
+++ b/providers/README.md
@@ -95,3 +95,35 @@ The context provides three functions:
 - `alias(newUserId, anonymousId)` – alias an anonymous user to a new id
 
 Wrap your application with `RudderStackProvider` to ensure events are sent securely from the server.
+
+---
+
+## OpenAIProvider
+
+`OpenAIProvider` wraps the OpenAI chat completion API. It is a server component and requires `OPENAI_API_KEY`.
+
+```bash
+OPENAI_API_KEY=<your api key>
+```
+
+### Usage
+
+Wrap your application's root layout with `OpenAIProvider` and call the helper hook `useOpenAI` from other server components.
+
+```tsx
+import { OpenAIProvider } from './providers/OpenAIProvider'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <OpenAIProvider>{children}</OpenAIProvider>
+}
+```
+
+```tsx
+import { useOpenAI } from '../providers/OpenAIProvider'
+
+export default async function Example() {
+  const { generateChat } = useOpenAI()
+  const res = await generateChat([{ role: 'user', content: 'hello' }])
+  return <pre>{JSON.stringify(res, null, 2)}</pre>
+}
+```

--- a/providers/__tests__/OpenAIProvider.test.tsx
+++ b/providers/__tests__/OpenAIProvider.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { OpenAIProvider } from '../OpenAIProvider'
+
+describe('OpenAIProvider', () => {
+  it('fails without env var', () => {
+    const key = process.env.OPENAI_API_KEY
+    const origWindow = (global as any).window
+    delete (global as any).window
+    delete process.env.OPENAI_API_KEY
+    expect(() =>
+      OpenAIProvider({ children: React.createElement('div') })
+    ).toThrow('OPENAI_API_KEY not set')
+    if (key) process.env.OPENAI_API_KEY = key
+    ;(global as any).window = origWindow
+  })
+
+  it('fails on the client', () => {
+    const key = process.env.OPENAI_API_KEY
+    ;(global as any).window = {}
+    process.env.OPENAI_API_KEY = 'test'
+    expect(() =>
+      OpenAIProvider({ children: React.createElement('div') })
+    ).toThrow('OpenAIProvider can only be used on the server')
+    if (key) process.env.OPENAI_API_KEY = key
+    else delete process.env.OPENAI_API_KEY
+    delete (global as any).window
+  })
+})

--- a/services/openai/AGENTS.md
+++ b/services/openai/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS – OpenAI Service
+
+Helper functions for calling the OpenAI chat completion API. Reads the API key from `OPENAI_API_KEY` and must be fully tested.

--- a/services/openai/__tests__/http.test.ts
+++ b/services/openai/__tests__/http.test.ts
@@ -1,0 +1,23 @@
+import { chatCompletion } from '../http'
+
+describe('openai http', () => {
+  it('fails without api key', async () => {
+    const orig = process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEY
+    await expect(chatCompletion([])).rejects.toThrow('OPENAI_API_KEY not set')
+    if (orig) process.env.OPENAI_API_KEY = orig
+  })
+
+  it('calls openai api', async () => {
+    const origFetch = global.fetch
+    process.env.OPENAI_API_KEY = 'test'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'abc' }),
+    } as any)
+    const res = await chatCompletion([{ role: 'user', content: 'hi' }])
+    expect(res.id).toBe('abc')
+    expect((global.fetch as any).mock.calls.length).toBe(1)
+    global.fetch = origFetch
+  })
+})

--- a/services/openai/http.ts
+++ b/services/openai/http.ts
@@ -1,0 +1,31 @@
+export interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+declare const process: {
+  env: {
+    OPENAI_API_KEY?: string;
+  };
+};
+
+export async function chatCompletion(
+  messages: ChatMessage[],
+  model = 'gpt-4o-mini',
+): Promise<any> {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error('OPENAI_API_KEY not set');
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({ model, messages }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`OpenAI error: ${res.status} - ${text}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `OpenAIProvider` React context and hook
- implement `openai` service with chat completion helper
- document the provider usage
- test OpenAI provider and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d86250f883289bd666c415cb1003