### PR TITLE
Add Global WL plan and scaffold pages

### DIFF
--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-goal-weight/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-goal-weight/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GoalWeight from '@/app/components/intake-v4/pages/goal-weight';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLGoalWeight({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GoalWeight />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-interactive/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-interactive/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import InteractiveBMI from '@/app/components/intake-v4/pages/interactive-bmi';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLInteractive({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <InteractiveBMI />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-medications/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-medications/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import MedicationOptions from '@/app/components/intake-v4/pages/medication-options';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLMedications({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <MedicationOptions />
+    </>
+  );
+}

--- a/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+export default function GoalWeight() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">What is your goal weight?</BioType>
+      <input type="number" className="border p-2" placeholder="Enter goal weight" />
+    </div>
+  );
+}

--- a/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+export default function InteractiveBMI() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">BMI Progress</BioType>
+      <div className="h-40 w-full border flex items-center justify-center">
+        {/* Visualization placeholder */}
+        <span className="text-sm text-gray-600">Graph updates as user enters weight</span>
+      </div>
+    </div>
+  );
+}

--- a/bioverse-client/app/components/intake-v4/pages/medication-options.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/medication-options.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+const MEDICATIONS = ['Ozempic', 'Mounjaro', 'Zepbound', 'BIOVERSE Weight Loss Capsule'];
+
+export default function MedicationOptions() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">Choose your medication</BioType>
+      <ul className="flex flex-col gap-2">
+        {MEDICATIONS.map((m) => (
+          <li key={m} className="border p-2 rounded-md cursor-pointer hover:bg-gray-50">{m}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -1,0 +1,18 @@
+# Global Weight Loss Funnel – Implementation Plan
+
+This document outlines the approach for **BV-3284 Build & Integrate New Global Weight Loss Funnel for A/B Testing**. The goal is to implement the redesigned funnel and prepare it for A/B testing against the existing version.
+
+## Objectives
+- Capture goal weight and display interactive BMI feedback.
+- Offer medication selection for Ozempic, Mounjaro, Zepbound and BIOVERSE Weight Loss Capsule.
+- Route 30% of users through this new funnel and keep 70% on the current flow.
+- Store new answers in the patient model and ensure DoseSpot integration for retail prescriptions.
+
+## Sprint Breakdown (15 points)
+1. **Page Scaffolding (3 pts)** – Create new route files and basic React components for goal weight input, interactive BMI feedback and medication selection.
+2. **Backend Updates (4 pts)** – Extend order and questionnaire controllers to store goal weight and selected medication. Add DoseSpot prescription logic for the new options.
+3. **A/B Split Logic (3 pts)** – Implement percentage based routing in the intake controller and verify that analytics capture which version a user sees.
+4. **Interactive Visualization (3 pts)** – Build responsive BMI graph that updates as the user enters goal weight.
+5. **Tracking & QA (2 pts)** – Ensure events flow to analytics and test both funnels across common devices.
+
+Success is achieved when the new funnel matches the Figma designs, integrates with backend services and can be toggled on for a percentage of traffic.


### PR DESCRIPTION
## Summary
- document implementation plan for BV-3284 global weight loss funnel
- scaffold placeholder components for goal weight, BMI feedback and medication options
- add new intake pages for the global WL funnel

## Testing
- `npm run check:links` *(fails: Cannot find module './check-links.ts')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6845dfa6c2188328ad73a8f109c1751d