### PR TITLE
Add BMG and Easypost providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 STRIPE_SK=sk_test_your_key
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-key
+BMG_API_KEY=your-bmg-key
+EASYPOST_API_KEY=your-easypost-key

--- a/providers/BmgProvider.tsx
+++ b/providers/BmgProvider.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react'
+
+interface BmgContextType {
+  sendEvent: (
+    orderId: number,
+    state: string,
+    event: string,
+    value: string,
+    sentAt: string,
+    currency: string,
+    utmSource: string,
+    contentName: string,
+    careSelection: string,
+    utmCampaign: string,
+    utmMedium: string,
+    utmContent: string,
+    utmTerm: string,
+    userId?: string,
+  ) => Promise<any>
+}
+
+const BmgContext = createContext<BmgContextType | null>(null)
+
+export function BmgProvider({ children }: PropsWithChildren) {
+  if (typeof window !== 'undefined') {
+    throw new Error('BmgProvider can only be used on the server')
+  }
+
+  if (!process.env.BMG_API_KEY) {
+    throw new Error('BMG_API_KEY not set')
+  }
+
+  const sendEvent: BmgContextType['sendEvent'] = async (
+    orderId,
+    state,
+    event,
+    value,
+    sentAt,
+    currency,
+    utmSource,
+    contentName,
+    careSelection,
+    utmCampaign,
+    utmMedium,
+    utmContent,
+    utmTerm,
+    userId,
+  ) => {
+    const { sendEventDataToBMG } = await import('../bioverse-client/app/services/bmg/bmg_functions')
+    return sendEventDataToBMG(
+      orderId,
+      state,
+      event,
+      value,
+      sentAt,
+      currency,
+      utmSource,
+      contentName,
+      careSelection,
+      utmCampaign,
+      utmMedium,
+      utmContent,
+      utmTerm,
+      userId,
+    )
+  }
+
+  return <BmgContext.Provider value={{ sendEvent }}>{children}</BmgContext.Provider>
+}
+
+export const useBmg = () => {
+  const context = useContext(BmgContext)
+  if (!context) throw new Error('useBmg must be used within BmgProvider')
+  return context
+}

--- a/providers/EasypostProvider.tsx
+++ b/providers/EasypostProvider.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react'
+
+interface EasypostContextType {
+  createTracker: (
+    orderId: string,
+    trackingNumber: string,
+    carrier: string,
+    pharmacy: string,
+  ) => Promise<void>
+  createTrackerForCustomOrders: (
+    customOrderId: string,
+    trackingNumber: string,
+    carrier: string,
+    pharmacy: string,
+  ) => Promise<void>
+}
+
+const EasypostContext = createContext<EasypostContextType | null>(null)
+
+export function EasypostProvider({ children }: PropsWithChildren) {
+  if (typeof window !== 'undefined') {
+    throw new Error('EasypostProvider can only be used on the server')
+  }
+
+  if (!process.env.EASYPOST_API_KEY) {
+    throw new Error('EASYPOST_API_KEY not set')
+  }
+
+  const createTrackerFn: EasypostContextType['createTracker'] = async (
+    orderId,
+    trackingNumber,
+    carrier,
+    pharmacy,
+  ) => {
+    const mod = await import('../bioverse-client/app/services/easypost/easypost-tracker')
+    return mod.createTracker(orderId, trackingNumber, carrier, pharmacy)
+  }
+
+  const createTrackerForCustomOrdersFn: EasypostContextType['createTrackerForCustomOrders'] = async (
+    customOrderId,
+    trackingNumber,
+    carrier,
+    pharmacy,
+  ) => {
+    const mod = await import('../bioverse-client/app/services/easypost/easypost-tracker')
+    return mod.createTrackerForCustomOrders(customOrderId, trackingNumber, carrier, pharmacy)
+  }
+
+  return (
+    <EasypostContext.Provider
+      value={{
+        createTracker: createTrackerFn,
+        createTrackerForCustomOrders: createTrackerForCustomOrdersFn,
+      }}
+    >
+      {children}
+    </EasypostContext.Provider>
+  )
+}
+
+export const useEasypost = () => {
+  const context = useContext(EasypostContext)
+  if (!context) throw new Error('useEasypost must be used within EasypostProvider')
+  return context
+}

--- a/providers/README.md
+++ b/providers/README.md
@@ -192,3 +192,67 @@ export default async function Example() {
   return null
 }
 ```
+
+---
+
+## BmgProvider
+
+`BmgProvider` sends marketing conversion events to BMG. It is a server component and requires `BMG_API_KEY`.
+
+```bash
+BMG_API_KEY=<api key>
+```
+
+### Usage
+
+Wrap your application's root layout with `BmgProvider` and call the helper hook `useBmg` from server components.
+
+```tsx
+import { BmgProvider } from './providers/BmgProvider'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <BmgProvider>{children}</BmgProvider>
+}
+```
+
+```tsx
+import { useBmg } from '../providers/BmgProvider'
+
+export default async function Example() {
+  const { sendEvent } = useBmg()
+  await sendEvent(1, 'CA', 'purchase', '20', new Date().toISOString(), 'USD', 'ads', 'product', 'selection', 'campaign', 'medium', 'content', 'term')
+  return null
+}
+```
+
+---
+
+## EasypostProvider
+
+`EasypostProvider` creates shipment trackers using the Easypost API. It is a server component and requires `EASYPOST_API_KEY`.
+
+```bash
+EASYPOST_API_KEY=<api key>
+```
+
+### Usage
+
+Wrap your application's root layout with `EasypostProvider` and call the helper hook `useEasypost` from server components.
+
+```tsx
+import { EasypostProvider } from './providers/EasypostProvider'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <EasypostProvider>{children}</EasypostProvider>
+}
+```
+
+```tsx
+import { useEasypost } from '../providers/EasypostProvider'
+
+export default async function Example() {
+  const { createTracker } = useEasypost()
+  await createTracker('123', '9400110898825022579493', 'USPS', 'curexa')
+  return null
+}
+```

--- a/providers/__tests__/BmgProvider.test.tsx
+++ b/providers/__tests__/BmgProvider.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { BmgProvider } from '../BmgProvider'
+
+describe('BmgProvider', () => {
+  it('fails without env var', () => {
+    const key = process.env.BMG_API_KEY
+    const origWindow = (global as any).window
+    delete (global as any).window
+    delete process.env.BMG_API_KEY
+    expect(() =>
+      BmgProvider({ children: React.createElement('div') })
+    ).toThrow('BMG_API_KEY not set')
+    if (key) process.env.BMG_API_KEY = key
+    ;(global as any).window = origWindow
+  })
+
+  it('fails on the client', () => {
+    const key = process.env.BMG_API_KEY
+    ;(global as any).window = {}
+    process.env.BMG_API_KEY = 'test'
+    expect(() =>
+      BmgProvider({ children: React.createElement('div') })
+    ).toThrow('BmgProvider can only be used on the server')
+    if (key) process.env.BMG_API_KEY = key
+    else delete process.env.BMG_API_KEY
+    delete (global as any).window
+  })
+})

--- a/providers/__tests__/EasypostProvider.test.tsx
+++ b/providers/__tests__/EasypostProvider.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { EasypostProvider } from '../EasypostProvider'
+
+describe('EasypostProvider', () => {
+  it('fails without env var', () => {
+    const key = process.env.EASYPOST_API_KEY
+    const origWindow = (global as any).window
+    delete (global as any).window
+    delete process.env.EASYPOST_API_KEY
+    expect(() =>
+      EasypostProvider({ children: React.createElement('div') })
+    ).toThrow('EASYPOST_API_KEY not set')
+    if (key) process.env.EASYPOST_API_KEY = key
+    ;(global as any).window = origWindow
+  })
+
+  it('fails on the client', () => {
+    const key = process.env.EASYPOST_API_KEY
+    ;(global as any).window = {}
+    process.env.EASYPOST_API_KEY = 'test'
+    expect(() =>
+      EasypostProvider({ children: React.createElement('div') })
+    ).toThrow('EasypostProvider can only be used on the server')
+    if (key) process.env.EASYPOST_API_KEY = key
+    else delete process.env.EASYPOST_API_KEY
+    delete (global as any).window
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
-      "*": ["*", "services/*", "providers/*"]
+      "*": ["*", "services/*", "providers/*"],
+      "@/*": ["bioverse-client/app/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## Summary
- add BmgProvider and EasypostProvider with dynamic imports
- include tests for new providers
- document env vars and usage in README
- update tsconfig paths and env example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845dd8c99f4832881b5e59e5e54870c