### PR TITLE
Implement global weight loss funnel scaffolding

### DIFF
--- a/bioverse-client/app/components/intake-v2/constants/route-constants.ts
+++ b/bioverse-client/app/components/intake-v2/constants/route-constants.ts
@@ -934,6 +934,18 @@ export const COMBINED_WEIGHT_LOSS_ROUTES: IntakeRouteSpecification = {
     },
 };
 
+export const GLOBAL_WL_ROUTES: IntakeRouteSpecification = {
+    1: {
+        version: 1,
+        route_array: [
+            INTAKE_ROUTE_V3.GLOBAL_WL_GOAL_WEIGHT,
+            INTAKE_ROUTE_V3.GLOBAL_WL_INTERACTIVE,
+            INTAKE_ROUTE_V3.GLOBAL_WL_MEDICATIONS,
+        ],
+        ab_tests: [],
+    },
+};
+
 export const SKINCARE_INTAKE_ROUTES: IntakeRouteSpecification = {
     1: {
         version: 1,
@@ -1153,6 +1165,7 @@ export const LATEST_INTAKE_VERSIONS: LatestIntakeSpecification = {
         route_array: COMBINED_WEIGHT_LOSS_ROUTES,
         latest_version: 2,
     },
+    global_wl: { route_array: GLOBAL_WL_ROUTES, latest_version: 1 },
     semaglutide: { route_array: SEMAGLUTIDE_ROUTES, latest_version: 1 },
     tirzepatide: { route_array: TIRZEPATIDE_ROUTES, latest_version: 1 },
     metformin: { route_array: METFORMIN_INTAKE_ROUTES, latest_version: 1 },

--- a/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
+++ b/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
@@ -217,4 +217,7 @@ export enum INTAKE_ROUTE_V3 {
     ORDER_SUMMARY_V3_AP = 'order-summary-v3-ap',
     ONE_MOMENT = 'one-moment',
     NEW_NON_WL_CHECKOUT = 'checkout-v3',
+    GLOBAL_WL_GOAL_WEIGHT = 'global-wl-goal-weight',
+    GLOBAL_WL_INTERACTIVE = 'global-wl-interactive',
+    GLOBAL_WL_MEDICATIONS = 'global-wl-medications',
 }

--- a/bioverse-client/app/utils/functions/intake-route-controller.ts
+++ b/bioverse-client/app/utils/functions/intake-route-controller.ts
@@ -3,6 +3,7 @@ import {
     STANDARD_INTAKE_ROUTES,
     NAD_INTAKE_ROUTES,
     COMBINED_WEIGHT_LOSS_ROUTES,
+    GLOBAL_WL_ROUTES,
     GLUTATHIONE_INTAKE_ROUTES,
     B12_INTAKE_ROUTES,
     SKINCARE_INTAKE_ROUTES,
@@ -708,6 +709,18 @@ export function getCurrentIntakeProgressBySection(
 
             routesArray = getRouteArrayForTest(
                 TIRZEPATIDE_ROUTES[current_version],
+                vwo_test_ids
+            );
+            break;
+        case PRODUCT_HREF.OZEMPIC:
+        case PRODUCT_HREF.MOUNJARO:
+        case PRODUCT_HREF.ZEPBOUND:
+        case PRODUCT_HREF.WL_CAPSULE:
+            const current_version_global =
+                LATEST_INTAKE_VERSIONS.global_wl.latest_version;
+
+            routesArray = getRouteArrayForTest(
+                GLOBAL_WL_ROUTES[current_version_global],
                 vwo_test_ids
             );
             break;


### PR DESCRIPTION
## Summary
- add new global weight loss route enums
- define `GLOBAL_WL_ROUTES` and expose in latest version map
- route ozempic, mounjaro, zepbound and capsule products through new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845e370b41083289d039768d0e86679