### PR TITLE
Enhance global weight loss funnel pages

### DIFF
--- a/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+import { useState } from 'react';
 
+/** Collects the patient's target weight. */
 export default function GoalWeight() {
+  const [weight, setWeight] = useState(180);
+
   return (
     <div className="flex flex-col items-center gap-4">
       <BioType className="inter-h5-question-header">What is your goal weight?</BioType>
-      <input type="number" className="border p-2" placeholder="Enter goal weight" />
+      <input
+        type="number"
+        className="border p-2"
+        value={weight}
+        onChange={(e) => setWeight(Number(e.target.value))}
+      />
     </div>
   );
 }

--- a/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
@@ -1,14 +1,46 @@
 'use client';
 
 import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+import { useState } from 'react';
 
+/**
+ * Renders an interactive BMI comparison graph. Users can adjust their
+ * current and goal weight to see projected BMI changes.
+ */
 export default function InteractiveBMI() {
+  const [currentWeight, setCurrentWeight] = useState(200);
+  const [goalWeight, setGoalWeight] = useState(180);
+  const HEIGHT_M = 1.75;
+
+  const currentBmi = currentWeight / (HEIGHT_M * HEIGHT_M);
+  const goalBmi = goalWeight / (HEIGHT_M * HEIGHT_M);
+
   return (
     <div className="flex flex-col items-center gap-4">
       <BioType className="inter-h5-question-header">BMI Progress</BioType>
-      <div className="h-40 w-full border flex items-center justify-center">
-        {/* Visualization placeholder */}
-        <span className="text-sm text-gray-600">Graph updates as user enters weight</span>
+      <div className="flex gap-4">
+        <label className="flex flex-col text-sm">
+          Current
+          <input
+            type="number"
+            className="border p-1 rounded"
+            value={currentWeight}
+            onChange={(e) => setCurrentWeight(Number(e.target.value))}
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          Goal
+          <input
+            type="number"
+            className="border p-1 rounded"
+            value={goalWeight}
+            onChange={(e) => setGoalWeight(Number(e.target.value))}
+          />
+        </label>
+      </div>
+      <div className="h-40 w-full border flex flex-col items-center justify-center gap-2">
+        <span className="text-xs text-gray-600">Current BMI: {currentBmi.toFixed(1)}</span>
+        <span className="text-xs text-gray-600">Goal BMI: {goalBmi.toFixed(1)}</span>
       </div>
     </div>
   );

--- a/bioverse-client/app/components/intake-v4/pages/medication-options.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/medication-options.tsx
@@ -1,16 +1,26 @@
 'use client';
 
 import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+import { useState } from 'react';
 
 const MEDICATIONS = ['Ozempic', 'Mounjaro', 'Zepbound', 'BIOVERSE Weight Loss Capsule'];
 
+/** Displays selectable medication options. */
 export default function MedicationOptions() {
+  const [selected, setSelected] = useState('');
+
   return (
     <div className="flex flex-col items-center gap-4">
       <BioType className="inter-h5-question-header">Choose your medication</BioType>
       <ul className="flex flex-col gap-2">
         {MEDICATIONS.map((m) => (
-          <li key={m} className="border p-2 rounded-md cursor-pointer hover:bg-gray-50">{m}</li>
+          <li
+            key={m}
+            className={`border p-2 rounded-md cursor-pointer hover:bg-gray-50 ${selected === m ? 'bg-gray-100' : ''}`}
+            onClick={() => setSelected(m)}
+          >
+            {m}
+          </li>
         ))}
       </ul>
     </div>

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -23,3 +23,4 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
   - `global-wl-interactive`
   - `global-wl-medications`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
+- Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.


### PR DESCRIPTION
## Summary
- make `GoalWeight` interactive
- add interactive BMI mockup
- allow medication selection
- update global weight loss implementation plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845ea7cb05083288b82783a7b52ccb7