### PR TITLE
Add global WL checkout scaffold

### DIFF
--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-checkout/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-checkout/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalWLCheckout from '@/app/components/intake-v4/pages/global-checkout';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLCheckoutPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalWLCheckout />
+    </>
+  );
+}

--- a/bioverse-client/app/components/intake-v2/constants/route-constants.ts
+++ b/bioverse-client/app/components/intake-v2/constants/route-constants.ts
@@ -941,6 +941,7 @@ export const GLOBAL_WL_ROUTES: IntakeRouteSpecification = {
             INTAKE_ROUTE_V3.GLOBAL_WL_GOAL_WEIGHT,
             INTAKE_ROUTE_V3.GLOBAL_WL_INTERACTIVE,
             INTAKE_ROUTE_V3.GLOBAL_WL_MEDICATIONS,
+            INTAKE_ROUTE_V3.GLOBAL_WL_CHECKOUT,
         ],
         ab_tests: [],
     },

--- a/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
+++ b/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
@@ -220,4 +220,5 @@ export enum INTAKE_ROUTE_V3 {
     GLOBAL_WL_GOAL_WEIGHT = 'global-wl-goal-weight',
     GLOBAL_WL_INTERACTIVE = 'global-wl-interactive',
     GLOBAL_WL_MEDICATIONS = 'global-wl-medications',
+    GLOBAL_WL_CHECKOUT = 'global-wl-checkout',
 }

--- a/bioverse-client/app/components/intake-v4/pages/global-checkout.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/global-checkout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import BioType from '../../global-components/bioverse-typography/bio-type/bio-type';
+
+/** Placeholder checkout screen for the global weight loss funnel. */
+export default function GlobalWLCheckout() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">Global WL Checkout</BioType>
+      <p className="text-sm text-gray-600">Checkout coming soon.</p>
+    </div>
+  );
+}

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -22,5 +22,6 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
   - `global-wl-goal-weight`
   - `global-wl-interactive`
   - `global-wl-medications`
+  - `global-wl-checkout`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
 - Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.


### PR DESCRIPTION
## Summary
- scaffold checkout page for the new global weight loss funnel
- document progress on the global WL implementation plan
- extend intake enums and route constants for new screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6845ef4b589c8328970526e1701aed27