### PR TITLE
Extend global WL funnel

### DIFF
--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-intro/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-intro/page.tsx
@@ -1,0 +1,21 @@
+'use server';
+
+import GlobalIntro from '@/app/components/intake-v4/pages/global-intro';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+    params: { product: string };
+    searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLIntroPage({
+    params,
+    searchParams,
+}: Props) {
+    const user_id = (await readUserSession()).data.session?.user.id!;
+    return (
+        <>
+            <GlobalIntro />
+        </>
+    );
+}

--- a/bioverse-client/app/components/intake-v2/constants/route-constants.ts
+++ b/bioverse-client/app/components/intake-v2/constants/route-constants.ts
@@ -193,7 +193,7 @@ export const SEMAGLUTIDE_ROUTES: IntakeRouteSpecification = {
     1: {
         version: 1,
         route_array: [
-            INTAKE_ROUTE_V3.WEIGHT_LOSS_ACCOMPLISH_GOALS, 
+            INTAKE_ROUTE_V3.WEIGHT_LOSS_ACCOMPLISH_GOALS,
             INTAKE_ROUTE_V3.WEIGHT_LOSS_BMI,
             INTAKE_ROUTE_V3.WEIGHT_LOSS_DATA_PROCESSING,
             INTAKE_ROUTE_V3.WEIGHT_LOSS_GRAPH_PRE_SIGNUP,
@@ -938,6 +938,7 @@ export const GLOBAL_WL_ROUTES: IntakeRouteSpecification = {
     1: {
         version: 1,
         route_array: [
+            INTAKE_ROUTE_V3.GLOBAL_WL_INTRO,
             INTAKE_ROUTE_V3.GLOBAL_WL_GOAL_WEIGHT,
             INTAKE_ROUTE_V3.GLOBAL_WL_INTERACTIVE,
             INTAKE_ROUTE_V3.GLOBAL_WL_MEDICATIONS,
@@ -1194,7 +1195,7 @@ export const LATEST_INTAKE_VERSIONS: LatestIntakeSpecification = {
         route_array: ED_X_PRODUCTS_INTAKE_ROUTES,
         latest_version: 1,
     },
-'x-chews': {
+    'x-chews': {
         route_array: ED_X_PRODUCTS_INTAKE_ROUTES,
         latest_version: 1,
     },
@@ -1202,5 +1203,4 @@ export const LATEST_INTAKE_VERSIONS: LatestIntakeSpecification = {
         latest_version: 1,
         route_array: SERMORELIN_ROUTES,
     },
-
 };

--- a/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
+++ b/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
@@ -121,7 +121,7 @@ export enum AB_TESTS_IDS {
     WL_RO_TEST = 'wl-ro-test',
     WL_NEW_SCREEN_TEST = 'wl-ns-test',
     SEM_SL = 'sem-sl', //semaglutide spring sale (ends may 16th, 2025) - also using this for global weight loss as well!
-    COMP_COMPARE = 'comp-compare', 
+    COMP_COMPARE = 'comp-compare',
     SEM_6MB = 'sem6mb', //ab test for a new 6 month biannual variant semaglutide revive
 }
 
@@ -217,6 +217,7 @@ export enum INTAKE_ROUTE_V3 {
     ORDER_SUMMARY_V3_AP = 'order-summary-v3-ap',
     ONE_MOMENT = 'one-moment',
     NEW_NON_WL_CHECKOUT = 'checkout-v3',
+    GLOBAL_WL_INTRO = 'global-wl-intro',
     GLOBAL_WL_GOAL_WEIGHT = 'global-wl-goal-weight',
     GLOBAL_WL_INTERACTIVE = 'global-wl-interactive',
     GLOBAL_WL_MEDICATIONS = 'global-wl-medications',

--- a/bioverse-client/app/components/intake-v4/pages/global-intro.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/global-intro.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+/** Simple intro page for the global weight loss funnel. */
+export default function GlobalIntro() {
+    return (
+        <div className="flex flex-col items-center gap-4">
+            <BioType className="inter-h5-question-header">
+                Welcome to Bioverse
+            </BioType>
+            <p className="text-sm text-gray-600">
+                Start your journey to better health.
+            </p>
+        </div>
+    );
+}

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -3,12 +3,14 @@
 This document outlines the approach for **BV-3284 Build & Integrate New Global Weight Loss Funnel for A/B Testing**. The goal is to implement the redesigned funnel and prepare it for A/B testing against the existing version.
 
 ## Objectives
+
 - Capture goal weight and display interactive BMI feedback.
 - Offer medication selection for Ozempic, Mounjaro, Zepbound and BIOVERSE Weight Loss Capsule.
 - Route 30% of users through this new funnel and keep 70% on the current flow.
 - Store new answers in the patient model and ensure DoseSpot integration for retail prescriptions.
 
 ## Sprint Breakdown (15 points)
+
 1. **Page Scaffolding (3 pts)** – Create new route files and basic React components for goal weight input, interactive BMI feedback and medication selection.
 2. **Backend Updates (4 pts)** – Extend order and questionnaire controllers to store goal weight and selected medication. Add DoseSpot prescription logic for the new options.
 3. **A/B Split Logic (3 pts)** – Implement percentage based routing in the intake controller and verify that analytics capture which version a user sees.
@@ -18,10 +20,12 @@ This document outlines the approach for **BV-3284 Build & Integrate New Global W
 Success is achieved when the new funnel matches the Figma designs, integrates with backend services and can be toggled on for a percentage of traffic.
 
 ## Progress
+
 - Initial pages for the new funnel have been scaffolded under `app/(intake)/intake/prescriptions/[product]/`:
   - `global-wl-goal-weight`
   - `global-wl-interactive`
   - `global-wl-medications`
   - `global-wl-checkout`
+  - `global-wl-intro`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
 - Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.


### PR DESCRIPTION
## Summary
- scaffold global WL intro page
- update route constants & enums
- document additional route

## Testing
- `npx prettier -w bioverse-client/app/components/intake-v4/pages/global-intro.tsx bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-intro/page.tsx bioverse-client/app/components/intake-v2/types/intake-enumerators.ts bioverse-client/app/components/intake-v2/constants/route-constants.ts docs/global-wl-plan.md`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f4e9c2248328a9aa050399dc98b0