### PR TITLE
Add order summary and next pages to global WL flow

### DIFF
--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-order-summary/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-order-summary/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalOrderSummary from '@/app/components/intake-v4/pages/global-order-summary';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLOrderSummaryPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalOrderSummary />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-whats-next/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-whats-next/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalWhatsNext from '@/app/components/intake-v4/pages/global-whats-next';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLWhatsNextPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalWhatsNext />
+    </>
+  );
+}

--- a/bioverse-client/app/components/intake-v2/constants/route-constants.ts
+++ b/bioverse-client/app/components/intake-v2/constants/route-constants.ts
@@ -944,6 +944,8 @@ export const GLOBAL_WL_ROUTES: IntakeRouteSpecification = {
             INTAKE_ROUTE_V3.GLOBAL_WL_MEDICATIONS,
             INTAKE_ROUTE_V3.GLOBAL_WL_CHECKOUT,
             INTAKE_ROUTE_V3.GLOBAL_WL_UP_NEXT,
+            INTAKE_ROUTE_V3.GLOBAL_WL_ORDER_SUMMARY,
+            INTAKE_ROUTE_V3.GLOBAL_WL_WHATS_NEXT,
         ],
         ab_tests: [],
     },

--- a/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
+++ b/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
@@ -223,4 +223,6 @@ export enum INTAKE_ROUTE_V3 {
     GLOBAL_WL_MEDICATIONS = 'global-wl-medications',
     GLOBAL_WL_CHECKOUT = 'global-wl-checkout',
     GLOBAL_WL_UP_NEXT = 'global-wl-up-next',
+    GLOBAL_WL_ORDER_SUMMARY = 'global-wl-order-summary',
+    GLOBAL_WL_WHATS_NEXT = 'global-wl-whats-next',
 }

--- a/bioverse-client/app/components/intake-v4/pages/global-order-summary.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/global-order-summary.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+/** Placeholder order summary screen for the global weight loss funnel. */
+export default function GlobalOrderSummary() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">Order Summary</BioType>
+      <p className="text-sm text-gray-600">Review your selections before finalizing.</p>
+    </div>
+  );
+}

--- a/bioverse-client/app/components/intake-v4/pages/global-whats-next.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/global-whats-next.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+
+/** Placeholder follow up screen for the global weight loss funnel. */
+export default function GlobalWhatsNext() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <BioType className="inter-h5-question-header">What's Next</BioType>
+      <p className="text-sm text-gray-600">We'll follow up with next steps shortly.</p>
+    </div>
+  );
+}

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -26,7 +26,9 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
   - `global-wl-interactive`
   - `global-wl-medications`
   - `global-wl-checkout`
-  - `global-wl-intro`
-  - `global-wl-up-next`
+- `global-wl-intro`
+- `global-wl-up-next`
+- `global-wl-order-summary`
+- `global-wl-whats-next`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
 - Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.


### PR DESCRIPTION
## Summary
- extend `INTAKE_ROUTE_V3` with `GLOBAL_WL_ORDER_SUMMARY` and `GLOBAL_WL_WHATS_NEXT`
- update global weight-loss route array
- scaffold order summary and whats next pages
- document the new pages in the implementation plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684606d8ae788328b3081f6ac43afc3c