### PR TITLE
Add WL plan details and endpoint tracing script

### DIFF
--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -32,3 +32,30 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
 - `global-wl-whats-next`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
 - Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.
+
+## Must Implement & API Requirements
+
+### Must Implement
+
+- Complete interactive form logic on each page.
+- Track analytics events for every screen.
+- Wire server-side validation for medication selection.
+- Persist BMI graph data between steps.
+
+### API Requirements
+
+- `POST /api/patient/goal-weight` – save the patient target weight.
+- `GET /api/products/weight-loss` – fetch medication options.
+- `POST /api/prescriptions/medication` – create the prescription record.
+- `POST /api/checkout/weight-loss` – finalize the order.
+
+### Timing Per Page (Existing Funnel Benchmarks)
+
+| Page | Reference | Est. Time |
+| --- | --- | --- |
+| `global-wl-goal-weight` | `wl-goal-weight` | ~0.5d |
+| `global-wl-interactive` | `wl-interactive` | ~1d |
+| `global-wl-medications` | `wl-medications` | ~0.5d |
+| `global-wl-checkout` | `wl-checkout` | ~0.5d |
+| `global-wl-order-summary` | `order-summary` | ~0.5d |
+| `global-wl-whats-next` | `whats-next` | ~0.25d |

--- a/scripts/audit/AGENTS.md
+++ b/scripts/audit/AGENTS.md
@@ -1,3 +1,3 @@
 # AGENTS – Audit Scripts
 
-Scripts in this folder generate code audit reports, call graphs and link checks. Run `npm run audit` to produce a new report in `.audit-history`. Avoid committing large intermediate files outside of that directory and keep dependencies minimal.
+Scripts in this folder generate code audit reports, call graphs and link checks. Run `npm run audit` to produce a new report in `.audit-history`. Avoid committing large intermediate files outside of that directory and keep dependencies minimal. The `endpoint-trace.ts` script resolves all API endpoints reachable from each TypeScript file by analyzing `call-graph.json`.

--- a/scripts/audit/audit-utils.ts
+++ b/scripts/audit/audit-utils.ts
@@ -17,6 +17,7 @@ interface Result {
   exports: ExportDetails[];
   usedIn: string[];
   httpEntry?: boolean;
+  apiEndpoints?: string[];
 }
 
 const results: Result[] = [];
@@ -78,5 +79,42 @@ function analyzeFile(filePath: string): Result {
 }
 
 walk(SOURCE_DIR);
+
+// map to compute reachable API endpoints using call-graph results
+try {
+  const callGraph: Array<{ source: string; calls: Record<string, string[]> }> = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'call-graph.json'), 'utf8')
+  );
+  const adjacency = new Map<string, Set<string>>();
+  const apiSet = new Set<string>();
+
+  for (const entry of callGraph) {
+    adjacency.set(entry.source, new Set(Object.keys(entry.calls)));
+    if (entry.source.includes('/pages/api/') || entry.source.includes('/app/api/')) {
+      apiSet.add(entry.source);
+    }
+  }
+
+  function collect(start: string, visited: Set<string> = new Set()): Set<string> {
+    if (visited.has(start)) return new Set();
+    visited.add(start);
+    const out = new Set<string>();
+    const calls = adjacency.get(start);
+    if (apiSet.has(start)) out.add(start);
+    if (calls) {
+      for (const mod of calls) {
+        if (apiSet.has(mod)) out.add(mod);
+        else collect(mod, visited).forEach(ep => out.add(ep));
+      }
+    }
+    return out;
+  }
+
+  for (const r of results) {
+    r.apiEndpoints = Array.from(collect(r.source));
+  }
+} catch {
+  console.warn('call-graph.json missing, apiEndpoints not computed');
+}
 fs.writeFileSync(path.join(ROOT, 'migration-plan.json'), JSON.stringify(results, null, 2));
 console.log(`Wrote ${results.length} entries to migration-plan.json`);

--- a/scripts/audit/endpoint-trace.ts
+++ b/scripts/audit/endpoint-trace.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.join(__dirname, '..');
+const callGraphPath = path.join(ROOT, 'call-graph.json');
+
+interface GraphEntry {
+  source: string;
+  calls: Record<string, string[]>;
+}
+
+let graphData: GraphEntry[] = [];
+try {
+  graphData = JSON.parse(fs.readFileSync(callGraphPath, 'utf8')) as GraphEntry[];
+} catch {
+  console.error('call-graph.json not found. Run call-graph.ts first.');
+  process.exit(1);
+}
+
+const adjacency = new Map<string, Set<string>>();
+const endpoints = new Set<string>();
+
+for (const entry of graphData) {
+  const modules = new Set<string>(Object.keys(entry.calls));
+  adjacency.set(entry.source, modules);
+  if (entry.source.includes('/pages/api/') || entry.source.includes('/app/api/')) {
+    endpoints.add(entry.source);
+  }
+}
+
+function trace(start: string, visited: Set<string> = new Set()): Set<string> {
+  if (visited.has(start)) return new Set();
+  visited.add(start);
+  const out = new Set<string>();
+
+  if (endpoints.has(start)) out.add(start);
+
+  const calls = adjacency.get(start);
+  if (calls) {
+    for (const mod of calls) {
+      if (endpoints.has(mod)) {
+        out.add(mod);
+      } else {
+        for (const ep of trace(mod, visited)) out.add(ep);
+      }
+    }
+  }
+  return out;
+}
+
+const traces: Record<string, string[]> = {};
+for (const file of adjacency.keys()) {
+  traces[file] = Array.from(trace(file));
+}
+
+fs.writeFileSync(path.join(ROOT, 'endpoint-trace.json'), JSON.stringify(traces, null, 2));
+console.log('Wrote endpoint-trace.json');

--- a/scripts/audit/run.ts
+++ b/scripts/audit/run.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 const SCRIPTS = [
   'call-graph.ts',
+  'endpoint-trace.ts',
   'audit-utils.ts',
   'check-links.ts',
   'audit-dashboard.ts'


### PR DESCRIPTION
## Summary
- outline must-implement items, API endpoints and time estimates in `global-wl-plan.md`
- update audit agents docs with new script
- compute reachable API endpoints in `audit-utils.ts`
- add `endpoint-trace.ts` and run it in audit pipeline

## Testing
- `npm run check:links` *(fails: several external links return errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68460af218948328a458ed7c5d40c2ba