### PR TITLE
Add funnel benchmarks and endpoint tracing

### DIFF
--- a/call-graph.json
+++ b/call-graph.json
@@ -1,2516 +1,8961 @@
 [
   {
     "source": "utils/unvalidatedUtils/actions/admin/dashboard-scripts.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getAllOrdersForAdminTable"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getAllRenewalOrdersForAdminOrderTable"
-      ],
-      "utils/unvalidatedUtils/actions/admin/parsers": [
-        "prescriptionRequestToAdminDashboard",
-        "renewalOrderToProviderDashboard"
-      ],
-      "lodash": [
-        "concat"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getAllOrdersForAdminTable",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 16,
+        "column": 15
+      },
+      {
+        "callee": "getAllRenewalOrdersForAdminOrderTable",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 18,
+        "column": 36
+      },
+      {
+        "callee": "prescriptionRequestToAdminDashboard",
+        "module": "utils/unvalidatedUtils/actions/admin/parsers",
+        "line": 26,
+        "column": 27
+      },
+      {
+        "callee": "renewalOrderToProviderDashboard",
+        "module": "utils/unvalidatedUtils/actions/admin/parsers",
+        "line": 30,
+        "column": 27
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 32,
+        "column": 26
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/admin/parsers.ts",
-    "calls": {
-      "utils/unvalidatedUtils/functions/dates": [
-        "getDateHourDifference"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getDateHourDifference",
+        "module": "utils/unvalidatedUtils/functions/dates",
+        "line": 41,
+        "column": 19
+      },
+      {
+        "callee": "getDateHourDifference",
+        "module": "utils/unvalidatedUtils/functions/dates",
+        "line": 78,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/alternatives/weight-loss/alternative-weight-loss-actions.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/actions/auth/session-reader": [
-        "readUserSession"
-      ],
-      "lodash": [
-        "isEmpty"
-      ],
-      "@/app/services/stripe/customer": [
-        "fetchDefaultCardForCustomer"
-      ],
-      "@/app/utils/database/controller/orders/orders-api": [
-        "fetchOrderData",
-        "insertNewManualOrder",
-        "updateOrder"
-      ],
-      "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "@/app/utils/functions/prescription-scripts/empower-approval-script-generator": [
-        "generateEmpowerScript"
-      ],
-      "@/app/services/pharmacy-integration/empower/provider-script-feedback": [
-        "processEmpowerScript"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 41,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "utils/unvalidatedUtils/actions/auth/session-reader",
+        "line": 42,
+        "column": 27
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 91,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 162,
+        "column": 22
+      },
+      {
+        "callee": "fetchDefaultCardForCustomer",
+        "module": "@/app/services/stripe/customer",
+        "line": 194,
+        "column": 43
+      },
+      {
+        "callee": "insertNewManualOrder",
+        "module": "@/app/utils/database/controller/orders/orders-api",
+        "line": 280,
+        "column": 34
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 283,
+        "column": 15
+      },
+      {
+        "callee": "updateOrder",
+        "module": "@/app/utils/database/controller/orders/orders-api",
+        "line": 293,
+        "column": 15
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "@/app/utils/database/controller/orders/orders-api",
+        "line": 303,
+        "column": 23
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 306,
+        "column": 23
+      },
+      {
+        "callee": "generateEmpowerScript",
+        "module": "@/app/utils/functions/prescription-scripts/empower-approval-script-generator",
+        "line": 308,
+        "column": 39
+      },
+      {
+        "callee": "processEmpowerScript",
+        "module": "@/app/services/pharmacy-integration/empower/provider-script-feedback",
+        "line": 322,
+        "column": 32
+      },
+      {
+        "callee": "updateOrder",
+        "module": "@/app/utils/database/controller/orders/orders-api",
+        "line": 335,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/auth-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/authorization.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/employees/employees-api": [
-        "getCurrentEmployeeRole"
-      ],
-      "utils/unvalidatedUtils/functions/auth/authorization/authorizaiton-helper": [
-        "determineAccessByRoleName"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getCurrentEmployeeRole",
+        "module": "utils/unvalidatedUtils/database/controller/employees/employees-api",
+        "line": 17,
+        "column": 19
+      },
+      {
+        "callee": "determineAccessByRoleName",
+        "module": "utils/unvalidatedUtils/functions/auth/authorization/authorizaiton-helper",
+        "line": 23,
+        "column": 25
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/change-email.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 19,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 34,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/oauth.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseBrowserClient": [
-        "createSupabaseBrowserClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseBrowserClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseBrowserClient",
+        "line": 24,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseBrowserClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseBrowserClient",
+        "line": 72,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseBrowserClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseBrowserClient",
+        "line": 116,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/server-signIn-signOut.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerClient",
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 25,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 40,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 58,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/session-reader.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerClient",
-        "createSupabaseServerComponentClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/employees/employees-api": [
-        "getEmployeeRecordById"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 18,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 23,
+        "column": 28
+      },
+      {
+        "callee": "getEmployeeRecordById",
+        "module": "utils/unvalidatedUtils/database/controller/employees/employees-api",
+        "line": 31,
+        "column": 39
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 50,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 63,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/auth/sign-out.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/check-up/check-up-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction",
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/functions/renewal-orders/renewal-orders": [
-        "getOrderStatusDetails"
-      ],
-      "lodash": [
-        "isNaN",
-        "isUndefined"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history": [
-        "logPatientAction"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getSubscriptionById",
-        "handleCheckUpSubscriptionExtension"
-      ],
-      "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "addOrRemoveStatusFlags"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "addCheckInCompletionToRenewalOrder",
-        "createFirstTimeRenewalOrder",
-        "createUpcomingRenewalOrder",
-        "getLatestRenewalOrderForSubscription",
-        "getMonthsIntoRenewalOrderSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/action-items/action-items-actions": [
-        "updateActionItem"
-      ],
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isGLP1Product"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 85,
+        "column": 19
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 111,
+        "column": 15
+      },
+      {
+        "callee": "getOrderStatusDetails",
+        "module": "utils/unvalidatedUtils/functions/renewal-orders/renewal-orders",
+        "line": 119,
+        "column": 26
+      },
+      {
+        "callee": "isUndefined",
+        "module": "lodash",
+        "line": 123,
+        "column": 13
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 124,
+        "column": 19
+      },
+      {
+        "callee": "isNaN",
+        "module": "lodash",
+        "line": 132,
+        "column": 13
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 133,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 166,
+        "column": 26
+      },
+      {
+        "callee": "logPatientAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history",
+        "line": 168,
+        "column": 15
+      },
+      {
+        "callee": "getSubscriptionById",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 196,
+        "column": 19
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 199,
+        "column": 15
+      },
+      {
+        "callee": "getLatestRenewalOrderForSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 229,
+        "column": 38
+      },
+      {
+        "callee": "handleCheckUpSubscriptionExtension",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 235,
+        "column": 15
+      },
+      {
+        "callee": "createFirstTimeRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 239,
+        "column": 38
+      },
+      {
+        "callee": "createUpcomingRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 253,
+        "column": 38
+      },
+      {
+        "callee": "addCheckInCompletionToRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 272,
+        "column": 15
+      },
+      {
+        "callee": "updateActionItem",
+        "module": "utils/unvalidatedUtils/database/controller/action-items/action-items-actions",
+        "line": 278,
+        "column": 15
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 305,
+        "column": 15
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 316,
+        "column": 23
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 319,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 327,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 333,
+        "column": 15
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 355,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 413,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 445,
+        "column": 22
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 461,
+        "column": 13
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 474,
+        "column": 13
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 492,
+        "column": 13
+      },
+      {
+        "callee": "getMonthsIntoRenewalOrderSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 493,
+        "column": 33
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 515,
+        "column": 13
+      },
+      {
+        "callee": "getMonthsIntoRenewalOrderSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 516,
+        "column": 33
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 543,
+        "column": 11
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/check-up/check-up-constants.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/coordinator/dashboard-scripts.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getAllLeadCoordinatorOrders",
-        "getAllOrdersForCoordinatorOrderTable"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getAllRenewalOrdersForCoordinatorOrderTable"
-      ],
-      "utils/unvalidatedUtils/actions/coordinator/parsers": [
-        "prescriptionRequestToCoordinatorDashboardv2",
-        "renewalOrderToCoordinatorDashboard"
-      ],
-      "lodash": [
-        "concat"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getAllOrdersForCoordinatorOrderTable",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 16,
+        "column": 15
+      },
+      {
+        "callee": "getAllRenewalOrdersForCoordinatorOrderTable",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 19,
+        "column": 15
+      },
+      {
+        "callee": "prescriptionRequestToCoordinatorDashboardv2",
+        "module": "utils/unvalidatedUtils/actions/coordinator/parsers",
+        "line": 28,
+        "column": 27
+      },
+      {
+        "callee": "renewalOrderToCoordinatorDashboard",
+        "module": "utils/unvalidatedUtils/actions/coordinator/parsers",
+        "line": 31,
+        "column": 27
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 32,
+        "column": 26
+      },
+      {
+        "callee": "getAllLeadCoordinatorOrders",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 40,
+        "column": 24
+      },
+      {
+        "callee": "prescriptionRequestToCoordinatorDashboardv2",
+        "module": "utils/unvalidatedUtils/actions/coordinator/parsers",
+        "line": 44,
+        "column": 25
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/coordinator/parsers.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/engineer/dashboard-scripts.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "getEngineerStatusTagOrders"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getEngineerStatusTagOrders",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 7,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/hhq-questionnaire.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 28,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 48,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/hooks/useLocalStorage.ts",
-    "calls": {
-      "react": [
-        "useEffect",
-        "useState"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "useState",
+        "module": "react",
+        "line": 6,
+        "column": 31
+      },
+      {
+        "callee": "useEffect",
+        "module": "react",
+        "line": 15,
+        "column": 5
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/order-control.ts",
-    "calls": {
-      "utils/services/stripe/setupIntent": [
-        "createSetupIntentServer"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSetupIntentServer",
+        "module": "utils/services/stripe/setupIntent",
+        "line": 15,
+        "column": 42
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 42,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 74,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 89,
+        "column": 10
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 107,
+        "column": 10
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 118,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 140,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 164,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 187,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/order-util.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getSubscriptionStatusFlagsFromOriginalOrderId",
-        "isActiveSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "updateOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history": [
-        "logPatientAction"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2": [
-        "getQuestionAnswersForBMI"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/empower-approval-script-generator": [
-        "generateEmpowerScript"
-      ],
-      "@/app/services/pharmacy-integration/empower/provider-script-feedback": [
-        "processEmpowerScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/hallandale-approval-script-generator": [
-        "generateHallandaleScript"
-      ],
-      "@/app/services/pharmacy-integration/hallandale/hallandale-script-api": [
-        "sendHallendaleScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/revive-script-generator": [
-        "generateReviveScript"
-      ],
-      "@/app/services/pharmacy-integration/revive/revive-send-script-api": [
-        "sendReviveScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/boothwyn-script-generator": [
-        "generateBoothwynScriptWithData"
-      ],
-      "@/app/services/pharmacy-integration/boothwyn/boothwyn-script-api": [
-        "sendBoothwynScript"
-      ],
-      "utils/unvalidatedUtils/database/controller/messaging/threads/threads": [
-        "getThreadIDByPatientIDAndProduct"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/containers/utils/post-prescribe-macro-selector/post-prescribe-macro-selector": [
-        "getProviderMacroHTMLPrePopulated"
-      ],
-      "utils/unvalidatedUtils/database/controller/messaging/messages/messages": [
-        "postNewMessage"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "isActiveSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 87,
+        "column": 38
+      },
+      {
+        "callee": "getSubscriptionStatusFlagsFromOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 111,
+        "column": 15
+      },
+      {
+        "callee": "updateOrder",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 153,
+        "column": 11
+      },
+      {
+        "callee": "logPatientAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history",
+        "line": 159,
+        "column": 11
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 168,
+        "column": 11
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 177,
+        "column": 11
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 182,
+        "column": 41
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 224,
+        "column": 15
+      },
+      {
+        "callee": "getQuestionAnswersForBMI",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2",
+        "line": 237,
+        "column": 27
+      },
+      {
+        "callee": "generateEmpowerScript",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/empower-approval-script-generator",
+        "line": 239,
+        "column": 27
+      },
+      {
+        "callee": "processEmpowerScript",
+        "module": "@/app/services/pharmacy-integration/empower/provider-script-feedback",
+        "line": 247,
+        "column": 24
+      },
+      {
+        "callee": "generateHallandaleScript",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/hallandale-approval-script-generator",
+        "line": 280,
+        "column": 30
+      },
+      {
+        "callee": "sendHallendaleScript",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-script-api",
+        "line": 304,
+        "column": 26
+      },
+      {
+        "callee": "generateReviveScript",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/revive-script-generator",
+        "line": 328,
+        "column": 32
+      },
+      {
+        "callee": "sendReviveScript",
+        "module": "@/app/services/pharmacy-integration/revive/revive-send-script-api",
+        "line": 343,
+        "column": 26
+      },
+      {
+        "callee": "generateBoothwynScriptWithData",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/boothwyn-script-generator",
+        "line": 369,
+        "column": 28
+      },
+      {
+        "callee": "sendBoothwynScript",
+        "module": "@/app/services/pharmacy-integration/boothwyn/boothwyn-script-api",
+        "line": 384,
+        "column": 26
+      },
+      {
+        "callee": "getThreadIDByPatientIDAndProduct",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/threads/threads",
+        "line": 409,
+        "column": 29
+      },
+      {
+        "callee": "getProviderMacroHTMLPrePopulated",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/post-prescribe-macro-selector/post-prescribe-macro-selector",
+        "line": 420,
+        "column": 33
+      },
+      {
+        "callee": "postNewMessage",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/messages/messages",
+        "line": 437,
+        "column": 11
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/product-data.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 5,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/intake/wl-supply.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 336,
+        "column": 31
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 340,
+        "column": 32
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 347,
+        "column": 31
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 355,
+        "column": 29
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 410,
+        "column": 17
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 411,
+        "column": 17
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 412,
+        "column": 17
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 413,
+        "column": 17
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/membership/membership-portal-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 22,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/membership/order-history-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 12,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 43,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 74,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 88,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 114,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/message/message-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/customerio/event_actions": [
-        "trackMessageEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 38,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 73,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 111,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 149,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 164,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 186,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 232,
+        "column": 22
+      },
+      {
+        "callee": "trackMessageEvent",
+        "module": "@/app/services/customerio/event_actions",
+        "line": 248,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 252,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 296,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 319,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 341,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 355,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 426,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 447,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/message/message-user.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 24,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 36,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/message/message-util.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/message/message-v2-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/messaging/threads/threads": [
-        "listAllThreadsForPatient"
-      ],
-      "utils/unvalidatedUtils/database/controller/messaging/messages/messages": [
-        "getMessagesForThread"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "listAllThreadsForPatient",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/threads/threads",
+        "line": 23,
+        "column": 32
+      },
+      {
+        "callee": "getMessagesForThread",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/messages/messages",
+        "line": 26,
+        "column": 37
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/message/messageTest.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 7,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 41,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/pdp-api/pdp-api.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 21,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 44,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 77,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 107,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 126,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 152,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/prescription-subscriptions/prescription-subscriptions-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getOrderDetailsById"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getRenewalOrder"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 17,
+        "column": 22
+      },
+      {
+        "callee": "getOrderDetailsById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 19,
+        "column": 39
+      },
+      {
+        "callee": "getRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 35,
+        "column": 36
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 63,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 86,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/active-subscriptions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 25,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/announcements.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 62,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 72,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 92,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 131,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 145,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/auth.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/check-for-renewal-order.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/dashboard-scripts.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/providers/providers-api": [
-        "getProviderLicensedStates",
-        "getProviderLicensedStatesWithID"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getAllOrdersForProviderOrderTablev2",
-        "getAllOrdersForTaskQueue"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getAllRenewalOrdersForProviderOrderTablev2",
-        "getAllRenewalOrdersForTaskQueue"
-      ],
-      "lodash": [
-        "concat"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/actions/provider/parsers": [
-        "prescriptionRequestToProviderDashboardv2",
-        "renewalOrderToProviderDashboard"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "getStatusTags"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getProviderLicensedStatesWithID",
+        "module": "utils/unvalidatedUtils/database/controller/providers/providers-api",
+        "line": 26,
+        "column": 35
+      },
+      {
+        "callee": "getAllOrdersForTaskQueue",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 29,
+        "column": 15
+      },
+      {
+        "callee": "getAllRenewalOrdersForTaskQueue",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 32,
+        "column": 15
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 44,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 90,
+        "column": 22
+      },
+      {
+        "callee": "getAllOrdersForProviderOrderTablev2",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 123,
+        "column": 15
+      },
+      {
+        "callee": "getAllRenewalOrdersForProviderOrderTablev2",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 128,
+        "column": 36
+      },
+      {
+        "callee": "prescriptionRequestToProviderDashboardv2",
+        "module": "utils/unvalidatedUtils/actions/provider/parsers",
+        "line": 136,
+        "column": 27
+      },
+      {
+        "callee": "renewalOrderToProviderDashboard",
+        "module": "utils/unvalidatedUtils/actions/provider/parsers",
+        "line": 144,
+        "column": 27
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 146,
+        "column": 26
+      },
+      {
+        "callee": "getProviderLicensedStates",
+        "module": "utils/unvalidatedUtils/database/controller/providers/providers-api",
+        "line": 148,
+        "column": 35
+      },
+      {
+        "callee": "getStatusTags",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 164,
+        "column": 36
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/get-suggested-dosages.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/parsers.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/patient-intake.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 22,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 38,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 66,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/patient-overview.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/prescription-requests.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 48,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 82,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 118,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/provider-dosespot.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/providers/providers-api": [
-        "getCurrentProviderDoseSpotId"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 28
+      },
+      {
+        "callee": "getCurrentProviderDoseSpotId",
+        "module": "utils/unvalidatedUtils/database/controller/providers/providers-api",
+        "line": 8,
+        "column": 30
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/provider/update-renewal-order-metadata.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 8,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/questionnaires/questionnaire-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire": [
-        "getQuestionAnswerWithQuestionID"
-      ],
-      "utils/unvalidatedUtils/functions/client-utils": [
-        "getCommonStringsSorted"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ],
-      "utils/unvalidatedUtils/actions/questionnaires/questionnaire-question-constants": [
-        "constructCheckupJunction",
-        "constructNonWeightlossCheckupQuestions",
-        "constructWeightlossCheckupQuestions"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getQuestionAnswerWithQuestionID",
+        "module": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire",
+        "line": 66,
+        "column": 32
+      },
+      {
+        "callee": "getCommonStringsSorted",
+        "module": "utils/unvalidatedUtils/functions/client-utils",
+        "line": 69,
+        "column": 32
+      },
+      {
+        "callee": "getQuestionAnswerWithQuestionID",
+        "module": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire",
+        "line": 134,
+        "column": 32
+      },
+      {
+        "callee": "getCommonStringsSorted",
+        "module": "utils/unvalidatedUtils/functions/client-utils",
+        "line": 137,
+        "column": 32
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 160,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 185,
+        "column": 26
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 222,
+        "column": 13
+      },
+      {
+        "callee": "constructNonWeightlossCheckupQuestions",
+        "module": "utils/unvalidatedUtils/actions/questionnaires/questionnaire-question-constants",
+        "line": 275,
+        "column": 35
+      },
+      {
+        "callee": "constructWeightlossCheckupQuestions",
+        "module": "utils/unvalidatedUtils/actions/questionnaires/questionnaire-question-constants",
+        "line": 279,
+        "column": 35
+      },
+      {
+        "callee": "constructCheckupJunction",
+        "module": "utils/unvalidatedUtils/actions/questionnaires/questionnaire-question-constants",
+        "line": 313,
+        "column": 40
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/questionnaires/questionnaire-question-constants.ts",
-    "calls": {
-      "lodash": [
-        "cloneDeep"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "cloneDeep",
+        "module": "lodash",
+        "line": 216,
+        "column": 31
+      },
+      {
+        "callee": "cloneDeep",
+        "module": "lodash",
+        "line": 244,
+        "column": 21
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/questionnaires/weightloss-questions/weightloss-questions-v1.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/questionnaires/weightloss-questions/weightloss-questions-v2.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/questionnaires/weightloss-questions/weightloss-questions-v3.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/stripe/stripe-webhook-actions.ts",
-    "calls": {
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history": [
-        "logPatientAction"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 15,
+        "column": 32
+      },
+      {
+        "callee": "logPatientAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history",
+        "line": 26,
+        "column": 11
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 30,
+        "column": 11
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 20,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 46,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 67,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 114,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 133,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/CommsScheduler/AnnuallyCheckInComms.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/CommsScheduler/BiannuallyCheckInComms.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/CommsScheduler/CommsSchedule.ts",
-    "calls": {
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getLatestRenewalOrderForOriginalOrderId"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 72,
+        "column": 44
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 82,
+        "column": 50
+      },
+      {
+        "callee": "getLatestRenewalOrderForOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 98,
+        "column": 27
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 106,
+        "column": 23
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 118,
+        "column": 44
+      },
+      {
+        "callee": "getLatestRenewalOrderForOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 129,
+        "column": 27
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 137,
+        "column": 23
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 148,
+        "column": 23
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 155,
+        "column": 23
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/CommsScheduler/MonthlyCheckInComms.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/CommsScheduler/ThreeMonthCheckInComms.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Dashboard.ts",
-    "calls": {
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "utils/unvalidatedUtils/functions/dates": [
-        "convertEpochToDate"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/containers/utils/intake-helpers": [
-        "getDaysBetweenDates",
-        "getIntakeDashboardTitle"
-      ],
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isGLP1Product",
-        "isWeightlossProduct"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getLatestProcessedOrderGeneral"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "utils/unvalidatedUtils/functions/formatting": [
-        "getFormattedCadence"
-      ],
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 48,
+        "column": 46
+      },
+      {
+        "callee": "convertEpochToDate",
+        "module": "utils/unvalidatedUtils/functions/dates",
+        "line": 52,
+        "column": 26
+      },
+      {
+        "callee": "getDaysBetweenDates",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/intake-helpers",
+        "line": 56,
+        "column": 39
+      },
+      {
+        "callee": "isWeightlossProduct",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 57,
+        "column": 17
+      },
+      {
+        "callee": "getLatestProcessedOrderGeneral",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 123,
+        "column": 19
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 125,
+        "column": 13
+      },
+      {
+        "callee": "getIntakeDashboardTitle",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/intake-helpers",
+        "line": 126,
+        "column": 26
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 139,
+        "column": 33
+      },
+      {
+        "callee": "getFormattedCadence",
+        "module": "utils/unvalidatedUtils/functions/formatting",
+        "line": 143,
+        "column": 32
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 148,
+        "column": 33
+      },
+      {
+        "callee": "getFormattedCadence",
+        "module": "utils/unvalidatedUtils/functions/formatting",
+        "line": 152,
+        "column": 32
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 206,
+        "column": 51
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 276,
+        "column": 51
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 450,
+        "column": 40
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 458,
+        "column": 46
+      },
+      {
+        "callee": "convertEpochToDate",
+        "module": "utils/unvalidatedUtils/functions/dates",
+        "line": 462,
+        "column": 34
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/DosingChangeController/DosageChangeConstantIndex.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/DosingChangeController/DosageChangeController.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/DosingChangeController/DosageChangeEquivalenceMap.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/DosingChangeController/DosageChangeModel.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Pharmacy.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getLastCompleteOrderForOriginalOrderId",
-        "updateRenewalOrderByRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-to-single-vial-converter": [
-        "getScriptForVariantIndex"
-      ],
-      "@/app/services/pharmacy-integration/empower/provider-script-feedback": [
-        "processAutomaticEmpowerScript"
-      ],
-      "@/app/services/pharmacy-integration/hallandale/hallandale-script-api": [
-        "processAutomaticHallandaleScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/prescription-scripts-utils": [
-        "updatePrescriptionScript"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit": [
-        "saveScriptForFutureUse"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getLastCompleteOrderForOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 65,
+        "column": 23
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 74,
+        "column": 23
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 90,
+        "column": 23
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 98,
+        "column": 54
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 102,
+        "column": 23
+      },
+      {
+        "callee": "getScriptForVariantIndex",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-to-single-vial-converter",
+        "line": 115,
+        "column": 23
+      },
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 127,
+        "column": 27
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 151,
+        "column": 19
+      },
+      {
+        "callee": "processAutomaticEmpowerScript",
+        "module": "@/app/services/pharmacy-integration/empower/provider-script-feedback",
+        "line": 191,
+        "column": 27
+      },
+      {
+        "callee": "processAutomaticHallandaleScript",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-script-api",
+        "line": 207,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 227,
+        "column": 15
+      },
+      {
+        "callee": "updatePrescriptionScript",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/prescription-scripts-utils",
+        "line": 234,
+        "column": 39
+      },
+      {
+        "callee": "saveScriptForFutureUse",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit",
+        "line": 239,
+        "column": 23
+      },
+      {
+        "callee": "saveScriptForFutureUse",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit",
+        "line": 247,
+        "column": 23
+      },
+      {
+        "callee": "saveScriptForFutureUse",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit",
+        "line": 255,
+        "column": 23
+      },
+      {
+        "callee": "saveScriptForFutureUse",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit",
+        "line": 263,
+        "column": 23
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 281,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/BestPharmacyMatrix.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/ProductVarianceMap.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/ProductVariantController.ts",
-    "calls": {
-      "utils/unvalidatedUtils/classes/ProductVariant/BestPharmacyMatrix": [
-        "findVariantPharmacyByState"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "findVariantPharmacyByState",
+        "module": "utils/unvalidatedUtils/classes/ProductVariant/BestPharmacyMatrix",
+        "line": 120,
+        "column": 51
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/ProductVariantModel.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/constants/ProductEquivalencyConstants.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/ProductVariant/constants/VariantPharmacyMap.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/BaseScriptHandler.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "updateRenewalOrderByRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical-notes": [
-        "getPatientAllergyData"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction",
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit": [
-        "saveScriptForFutureUse"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 191,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 220,
+        "column": 27
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 246,
+        "column": 60
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 251,
+        "column": 19
+      },
+      {
+        "callee": "getPatientAllergyData",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical-notes",
+        "line": 254,
+        "column": 19
+      },
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 262,
+        "column": 15
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 267,
+        "column": 15
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 286,
+        "column": 15
+      },
+      {
+        "callee": "saveScriptForFutureUse",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit",
+        "line": 295,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/BoothwynScriptHandler.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/boothwyn/boothwyn-script-api": [
-        "processAutomaticBoothwynScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/boothwyn-script-generator": [
-        "generateBoothwynScriptAsync"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "updateRenewalOrderFromRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "updatePrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "processAutomaticBoothwynScript",
+        "module": "@/app/services/pharmacy-integration/boothwyn/boothwyn-script-api",
+        "line": 17,
+        "column": 27
+      },
+      {
+        "callee": "generateBoothwynScriptAsync",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/boothwyn-script-generator",
+        "line": 42,
+        "column": 43
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 49,
+        "column": 41
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 55,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrderFromRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 67,
+        "column": 23
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 81,
+        "column": 27
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 100,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/EmpowerScriptHandler.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/empower/provider-script-feedback": [
-        "processAutomaticEmpowerScript"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2": [
-        "getQuestionAnswersForBMI"
-      ],
-      "@/app/utils/functions/prescription-scripts/empower-approval-script-generator": [
-        "generateEmpowerScriptAsync"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "updateRenewalOrderByRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "updatePrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "processAutomaticEmpowerScript",
+        "module": "@/app/services/pharmacy-integration/empower/provider-script-feedback",
+        "line": 21,
+        "column": 27
+      },
+      {
+        "callee": "getQuestionAnswersForBMI",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2",
+        "line": 41,
+        "column": 35
+      },
+      {
+        "callee": "generateEmpowerScriptAsync",
+        "module": "@/app/utils/functions/prescription-scripts/empower-approval-script-generator",
+        "line": 46,
+        "column": 42
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 53,
+        "column": 41
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 59,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrderByRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 71,
+        "column": 23
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 85,
+        "column": 27
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/HallandaleScriptHandler.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/hallandale/hallandale-script-api": [
-        "processAutomaticHallandaleScript"
-      ],
-      "@/app/utils/functions/prescription-scripts/hallandale-approval-script-generator": [
-        "generateHallandaleScriptAsync"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/hallandale/utils/hallandale-base64-pdf": [
-        "convertHallandaleOrderToBase64"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "updateRenewalOrderFromRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "updatePrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "processAutomaticHallandaleScript",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-script-api",
+        "line": 23,
+        "column": 27
+      },
+      {
+        "callee": "generateHallandaleScriptAsync",
+        "module": "@/app/utils/functions/prescription-scripts/hallandale-approval-script-generator",
+        "line": 56,
+        "column": 46
+      },
+      {
+        "callee": "convertHallandaleOrderToBase64",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/hallandale/utils/hallandale-base64-pdf",
+        "line": 64,
+        "column": 39
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 84,
+        "column": 45
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 90,
+        "column": 31
+      },
+      {
+        "callee": "updateRenewalOrderFromRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 102,
+        "column": 27
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 116,
+        "column": 31
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 140,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/ReviveScriptHandler.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/revive/revive-send-script-api": [
-        "processAutomaticReviveScript"
-      ],
-      "utils/unvalidatedUtils/functions/prescription-scripts/revive-script-generator": [
-        "generateReviveScript"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "updateRenewalOrderFromRenewalOrderId"
-      ],
-      "utils/unvalidatedUtils/actions/subscriptions/subscription-actions": [
-        "updatePrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "processAutomaticReviveScript",
+        "module": "@/app/services/pharmacy-integration/revive/revive-send-script-api",
+        "line": 17,
+        "column": 27
+      },
+      {
+        "callee": "generateReviveScript",
+        "module": "utils/unvalidatedUtils/functions/prescription-scripts/revive-script-generator",
+        "line": 42,
+        "column": 54
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 49,
+        "column": 41
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 55,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrderFromRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 67,
+        "column": 23
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "utils/unvalidatedUtils/actions/subscriptions/subscription-actions",
+        "line": 81,
+        "column": 27
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 100,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/Scripts/ScriptHandlerFactory.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/SigVisualizer/SigVisualizer.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data": [
-        "getEmpowerCatalogObject"
-      ],
-      "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data": [
-        "getHallandaleCatalogObject"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getEmpowerCatalogObject",
+        "module": "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data",
+        "line": 95,
+        "column": 42
+      },
+      {
+        "callee": "getHallandaleCatalogObject",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data",
+        "line": 126,
+        "column": 45
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/classes/SigVisualizer/sig-visualizer.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/clients/supabaseBrowserClient.ts",
-    "calls": {
-      "@supabase/ssr": [
-        "createBrowserClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createBrowserClient",
+        "module": "@supabase/ssr",
+        "line": 5,
+        "column": 12
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/clients/supabaseReqResClient.ts",
-    "calls": {
-      "@supabase/ssr": [
-        "createServerClient"
-      ],
-      "cookies-next": [
-        "getCookie",
-        "setCookie"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createServerClient",
+        "module": "@supabase/ssr",
+        "line": 5,
+        "column": 12
+      },
+      {
+        "callee": "getCookie",
+        "module": "cookies-next",
+        "line": 11,
+        "column": 28
+      },
+      {
+        "callee": "setCookie",
+        "module": "cookies-next",
+        "line": 14,
+        "column": 21
+      },
+      {
+        "callee": "setCookie",
+        "module": "cookies-next",
+        "line": 17,
+        "column": 21
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/clients/supabaseServerClient.ts",
-    "calls": {
-      "next/headers": [
-        "cookies"
-      ],
-      "@supabase/ssr": [
-        "createServerClient"
-      ],
-      "@supabase/supabase-js": [
-        "createClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "cookies",
+        "module": "next/headers",
+        "line": 6,
+        "column": 25
+      },
+      {
+        "callee": "createServerClient",
+        "module": "@supabase/ssr",
+        "line": 8,
+        "column": 12
+      },
+      {
+        "callee": "createClient",
+        "module": "@supabase/supabase-js",
+        "line": 38,
+        "column": 12
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/VWO/vwo_test_mappings.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/clinical-note-template-latest-versions.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/clinical-note-template-product-map.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/intake.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/provider-portal/ProviderTasks.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/acarbose-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/atorvastatin-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/b12-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/cgm-sensor-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/ed-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/glp-1-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/glutathione-injection-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/metformin-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/minoxidil-finasteride-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/nad-product-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/skin-care-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/telmisartan-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/wl-capsule-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/constants/templates/zofran-templates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/api-controller/discounts/database-discounts-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/api-controller/order_management/admin-order-management.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 12,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/api-controller/product_prices/product-prices.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/api-controller/products/products.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 5,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/action-items/action-items-actions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "lodash": [
-        "isEmpty",
-        "isUndefined"
-      ],
-      "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire_sessions": [
-        "createQuestionnaireSessionForCheckup"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 20,
+        "column": 22
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 49,
+        "column": 15
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 53,
+        "column": 9
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 60,
+        "column": 15
+      },
+      {
+        "callee": "createQuestionnaireSessionForCheckup",
+        "module": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire_sessions",
+        "line": 84,
+        "column": 44
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 93,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 108,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 138,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 167,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 180,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 206,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 232,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 255,
+        "column": 22
+      },
+      {
+        "callee": "isUndefined",
+        "module": "lodash",
+        "line": 257,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 282,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 296,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 306,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 324,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 345,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 355,
+        "column": 22
+      },
+      {
+        "callee": "isUndefined",
+        "module": "lodash",
+        "line": 357,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 384,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 411,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 462,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 487,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/admin_controlled_items/admin-controlled-items.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 23,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 43,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/admin_order_cancel_audit/admin-order-cancel-audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/ai_generation_audit/ai_generation_audit_api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 12,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical-notes.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 17,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 46,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 96,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "utils/unvalidatedUtils/actions/auth/session-reader",
+        "line": 98,
+        "column": 35
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 198,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 220,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 240,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 261,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_enums.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ],
-      "date-fns": [
-        "parseISO"
-      ],
-      "utils/unvalidatedUtils/database/controller/profiles/profiles": [
-        "updateCurrentProfileHeight"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 17,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 42,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 63,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 91,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 146,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 174,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 206,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 239,
+        "column": 36
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 285,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 391,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 428,
+        "column": 36
+      },
+      {
+        "callee": "parseISO",
+        "module": "date-fns",
+        "line": 436,
+        "column": 34
+      },
+      {
+        "callee": "parseISO",
+        "module": "date-fns",
+        "line": 515,
+        "column": 34
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 550,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 566,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 617,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 707,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 735,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 801,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 834,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 869,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 918,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 956,
+        "column": 22
+      },
+      {
+        "callee": "updateCurrentProfileHeight",
+        "module": "utils/unvalidatedUtils/database/controller/profiles/profiles",
+        "line": 976,
+        "column": 11
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getAllOrdersForCoordinatorOrderTable"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getAllRenewalOrdersForCoordinatorOrderTable"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 60,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 75,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 90,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 108,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 124,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 139,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 167,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 192,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 226,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 320,
+        "column": 22
+      },
+      {
+        "callee": "getAllOrdersForCoordinatorOrderTable",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 339,
+        "column": 15
+      },
+      {
+        "callee": "getAllRenewalOrdersForCoordinatorOrderTable",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 342,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 354,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/coordinator_activity_audit/coordinator_activity_audit.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/coordinator_tasks/coordinator-task-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 29,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 44,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 96,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 164,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 183,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 200,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 202,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 227,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 229,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 255,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 276,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/custom_orders/custom_orders_api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "isRenewalOrder"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 19,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 35,
+        "column": 22
+      },
+      {
+        "callee": "isRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 67,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 79,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 101,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 112,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/customerio_audit/audit_customerio.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/dose_spot_webhook_audit/dose-spot-webhook-audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/ds_match_failures/ds-match-failures.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 15,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/employees/employees-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 24,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 43,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 65,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 68,
+        "column": 32
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/employees/employees-database-type.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/escalations/escalations-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 21,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 36,
+        "column": 22
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 47,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 55,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 70,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 88,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 106,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/internal_notes/internal-notes-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 12,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/job-scheduler/job-scheduler-actions.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering",
-        "getStatusTagForOrder",
-        "updateStatusTagToReview"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getBaseOrderById"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 27,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 43,
+        "column": 22
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 61,
+        "column": 19
+      },
+      {
+        "callee": "getStatusTagForOrder",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 78,
+        "column": 37
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 80,
+        "column": 23
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 95,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 119,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 135,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 148,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 164,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 180,
+        "column": 22
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 193,
+        "column": 33
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 197,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 209,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 225,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 241,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 261,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 281,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/macros/macros-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 25,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 63,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 79,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 101,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 122,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 150,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 169,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/macros/macros-dbtype.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/macros/macros-types.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/macros/macros.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
+  },
+  {
+    "source": "utils/unvalidatedUtils/database/controller/marketing_opt_ins/marketing.tsx",
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 8,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/messaging/messages/messages.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history": [
-        "logPatientAction"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/macros/macros-api": [
-        "getMacroById"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "@/app/utils/functions/dates": [
-        "convertEpochToDate"
-      ],
-      "utils/unvalidatedUtils/database/controller/providers/providers-api": [
-        "getProviderFromId"
-      ],
-      "utils/unvalidatedUtils/database/controller/macros/macros": [
-        "replaceParametersAutomaticSend"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 26,
+        "column": 22
+      },
+      {
+        "callee": "logPatientAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history",
+        "line": 45,
+        "column": 11
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 70,
+        "column": 19
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 72,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 93,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 121,
+        "column": 28
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 152,
+        "column": 32
+      },
+      {
+        "callee": "getMacroById",
+        "module": "utils/unvalidatedUtils/database/controller/macros/macros-api",
+        "line": 156,
+        "column": 54
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 170,
+        "column": 38
+      },
+      {
+        "callee": "convertEpochToDate",
+        "module": "@/app/utils/functions/dates",
+        "line": 176,
+        "column": 30
+      },
+      {
+        "callee": "getProviderFromId",
+        "module": "utils/unvalidatedUtils/database/controller/providers/providers-api",
+        "line": 185,
+        "column": 32
+      },
+      {
+        "callee": "replaceParametersAutomaticSend",
+        "module": "utils/unvalidatedUtils/database/controller/macros/macros",
+        "line": 197,
+        "column": 30
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 205,
+        "column": 11
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/messaging/thread_escalations/thread_escalations.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 7,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 30,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 34,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 115,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 183,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 196,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 233,
+        "column": 21
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 260,
+        "column": 21
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 280,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 310,
+        "column": 21
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 331,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/messaging/thread_members/thread_members.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 35,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 57,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/messaging/threads/threads.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ],
-      "utils/unvalidatedUtils/database/controller/messaging/messages/messages": [
-        "getFirstMessageForThread"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 20,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 52,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 102,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 128,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 130,
+        "column": 28
+      },
+      {
+        "callee": "getFirstMessageForThread",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/messages/messages",
+        "line": 151,
+        "column": 42
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 172,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/mixpanel/mixpanel.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 17,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 41,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 67,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 113,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 138,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/order_data_audit/order_audit_descriptions.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 24,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 48,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 69,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 87,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 135,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 170,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 226,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_type.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/address-in-most-recent-order.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/create-manual-order.ts",
-    "calls": {
-      "@/app/utils/database/controller/products/products": [
-        "getPriceIdForProductVariant"
-      ],
-      "@/app/utils/functions/pricing": [
-        "isGLP1Product"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getSubscriptionByProduct"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getBaseOrderByProduct"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/create-order": [
-        "getPriceForStripePriceId"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeInvoice",
-        "getStripeSubscription"
-      ],
-      "@/app/utils/functions/dates": [
-        "convertEpochToDate"
-      ],
-      "@/app/utils/functions/client-utils": [
-        "formatDateToMMDDYYYY"
-      ],
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/messaging/threads/threads": [
-        "createNewThreadForPatientProduct"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 56,
+        "column": 32
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "@/app/utils/functions/pricing",
+        "line": 62,
+        "column": 10
+      },
+      {
+        "callee": "getSubscriptionByProduct",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 76,
+        "column": 30
+      },
+      {
+        "callee": "getBaseOrderByProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 82,
+        "column": 33
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 90,
+        "column": 31
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 97,
+        "column": 31
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 109,
+        "column": 27
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 116,
+        "column": 11
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 117,
+        "column": 11
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 140,
+        "column": 28
+      },
+      {
+        "callee": "getStripeInvoice",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 153,
+        "column": 37
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 233,
+        "column": 29
+      },
+      {
+        "callee": "convertEpochToDate",
+        "module": "@/app/utils/functions/dates",
+        "line": 235,
+        "column": 18
+      },
+      {
+        "callee": "formatDateToMMDDYYYY",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 237,
+        "column": 12
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 271,
+        "column": 28
+      },
+      {
+        "callee": "getStripeInvoice",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 277,
+        "column": 33
+      },
+      {
+        "callee": "getPriceForStripePriceId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order",
+        "line": 318,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 374,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 424,
+        "column": 26
+      },
+      {
+        "callee": "createNewThreadForPatientProduct",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/threads/threads",
+        "line": 437,
+        "column": 19
+      },
+      {
+        "callee": "createNewThreadForPatientProduct",
+        "module": "utils/unvalidatedUtils/database/controller/messaging/threads/threads",
+        "line": 449,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/create-order-utils.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/create-order.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "deleteOrderById",
-        "getBaseOrderByProduct",
-        "insertNewManualOrder",
-        "updateOrder"
-      ],
-      "@/app/utils/database/controller/products/products": [
-        "getPriceIdForProductVariant"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "createRenewalOrderWithPayload",
-        "getLatestOrderForSubscriptionThatWasSent",
-        "getLatestRenewalOrderByCustomerAndProduct"
-      ],
-      "@/app/utils/functions/client-utils": [
-        "convertStripePriceToDollars"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "cancelStripeSubscriptionManualOrder",
-        "createBalanceTransaction",
-        "getStripePriceId",
-        "listPaidInvoices",
-        "refundStripeInvoice",
-        "updateStripeProductWithProduct"
-      ],
-      "@/app/utils/actions/prescription-subscriptions/prescription-subscriptions-actions": [
-        "getAllActiveGLP1SubscriptionsForProduct"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "updateStatusTagToReview"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription",
-        "updatePrescriptionSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/create-order-utils": [
-        "getNextRenewalOrderId"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getBaseOrderByProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 55,
+        "column": 29
+      },
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 70,
+        "column": 32
+      },
+      {
+        "callee": "getLatestRenewalOrderByCustomerAndProduct",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 107,
+        "column": 19
+      },
+      {
+        "callee": "getBaseOrderByProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 157,
+        "column": 29
+      },
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 172,
+        "column": 32
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 230,
+        "column": 24
+      },
+      {
+        "callee": "getLatestRenewalOrderByCustomerAndProduct",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 239,
+        "column": 19
+      },
+      {
+        "callee": "deleteOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 248,
+        "column": 19
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 286,
+        "column": 24
+      },
+      {
+        "callee": "getStripePriceId",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 298,
+        "column": 31
+      },
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 324,
+        "column": 27
+      },
+      {
+        "callee": "createBalanceTransaction",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 341,
+        "column": 15
+      },
+      {
+        "callee": "refundStripeInvoice",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 348,
+        "column": 36
+      },
+      {
+        "callee": "insertNewManualOrder",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 381,
+        "column": 29
+      },
+      {
+        "callee": "getAllActiveGLP1SubscriptionsForProduct",
+        "module": "@/app/utils/actions/prescription-subscriptions/prescription-subscriptions-actions",
+        "line": 384,
+        "column": 37
+      },
+      {
+        "callee": "cancelStripeSubscriptionManualOrder",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 390,
+        "column": 19
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 393,
+        "column": 15
+      },
+      {
+        "callee": "getLatestRenewalOrderByCustomerAndProduct",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 398,
+        "column": 19
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 407,
+        "column": 34
+      },
+      {
+        "callee": "getAllActiveGLP1SubscriptionsForProduct",
+        "module": "@/app/utils/actions/prescription-subscriptions/prescription-subscriptions-actions",
+        "line": 412,
+        "column": 41
+      },
+      {
+        "callee": "getNextRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order-utils",
+        "line": 437,
+        "column": 38
+      },
+      {
+        "callee": "updateStripeProductWithProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 444,
+        "column": 23
+      },
+      {
+        "callee": "updateStripeProductWithProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 450,
+        "column": 23
+      },
+      {
+        "callee": "createRenewalOrderWithPayload",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 479,
+        "column": 19
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 481,
+        "column": 19
+      },
+      {
+        "callee": "createRenewalOrderWithPayload",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 507,
+        "column": 23
+      },
+      {
+        "callee": "updateStripeProductWithProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 509,
+        "column": 23
+      },
+      {
+        "callee": "createRenewalOrderWithPayload",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 535,
+        "column": 23
+      },
+      {
+        "callee": "updateStripeProductWithProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 537,
+        "column": 23
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 545,
+        "column": 15
+      },
+      {
+        "callee": "insertNewManualOrder",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 608,
+        "column": 24
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 611,
+        "column": 15
+      },
+      {
+        "callee": "updateOrder",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 645,
+        "column": 11
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 647,
+        "column": 11
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 658,
+        "column": 20
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 659,
+        "column": 27
+      },
+      {
+        "callee": "listPaidInvoices",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 665,
+        "column": 32
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 672,
+        "column": 20
+      },
+      {
+        "callee": "convertStripePriceToDollars",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 677,
+        "column": 20
+      },
+      {
+        "callee": "getAllActiveGLP1SubscriptionsForProduct",
+        "module": "@/app/utils/actions/prescription-subscriptions/prescription-subscriptions-actions",
+        "line": 748,
+        "column": 33
+      },
+      {
+        "callee": "getLatestOrderForSubscriptionThatWasSent",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 761,
+        "column": 15
+      },
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 769,
+        "column": 32
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/order-matching-dose-spot.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 96,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 149,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 202,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 249,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 301,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 354,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 408,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/orders-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "concat",
-        "isEmpty"
-      ],
-      "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire_sessions": [
-        "createQuestionnaireSessionForOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceVariantTableData"
-      ],
-      "@/app/utils/actions/intake/order-util": [
-        "getOrderType"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getLatestRenewalOrderForOriginalOrderId",
-        "getRenewalOrderForPatientIntake",
-        "updateRenewalOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit": [
-        "auditShippingTrackingFailed"
-      ],
-      "@/app/services/pharmacy-integration/revive/revive-patient-api": [
-        "changePatientAddressInReviveIfNecessary"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 48,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 70,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 92,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 111,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 134,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 160,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 187,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 237,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 271,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 301,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 376,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 454,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 510,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 561,
+        "column": 22
+      },
+      {
+        "callee": "createQuestionnaireSessionForOrder",
+        "module": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire_sessions",
+        "line": 597,
+        "column": 44
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 615,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 646,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 673,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 701,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 803,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 835,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 855,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 954,
+        "column": 22
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 980,
+        "column": 26
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 998,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1021,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1045,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1069,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1118,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1167,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 1179,
+        "column": 18
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 1190,
+        "column": 29
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1273,
+        "column": 28
+      },
+      {
+        "callee": "getPriceVariantTableData",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 1290,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1316,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1361,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1386,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1417,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1477,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1574,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1601,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1624,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1647,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1699,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1716,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1733,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1757,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1774,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1841,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1870,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1891,
+        "column": 22
+      },
+      {
+        "callee": "getOrderType",
+        "module": "@/app/utils/actions/intake/order-util",
+        "line": 1909,
+        "column": 29
+      },
+      {
+        "callee": "getRenewalOrderForPatientIntake",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 1921,
+        "column": 29
+      },
+      {
+        "callee": "getOrderType",
+        "module": "@/app/utils/actions/intake/order-util",
+        "line": 1932,
+        "column": 29
+      },
+      {
+        "callee": "getRenewalOrderForPatientIntake",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 1944,
+        "column": 29
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1955,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1973,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2000,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2037,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2057,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2098,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2116,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2140,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2167,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2204,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2247,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2285,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2303,
+        "column": 22
+      },
+      {
+        "callee": "auditShippingTrackingFailed",
+        "module": "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit",
+        "line": 2344,
+        "column": 13
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2368,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2406,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2457,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2514,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2545,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2570,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2605,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2656,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2684,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2709,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2724,
+        "column": 22
+      },
+      {
+        "callee": "concat",
+        "module": "lodash",
+        "line": 2744,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2755,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2773,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2791,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2825,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2887,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2920,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 2957,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3005,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3030,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3047,
+        "column": 22
+      },
+      {
+        "callee": "auditShippingTrackingFailed",
+        "module": "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit",
+        "line": 3074,
+        "column": 13
+      },
+      {
+        "callee": "auditShippingTrackingFailed",
+        "module": "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit",
+        "line": 3105,
+        "column": 13
+      },
+      {
+        "callee": "auditShippingTrackingFailed",
+        "module": "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit",
+        "line": 3116,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3137,
+        "column": 22
+      },
+      {
+        "callee": "getLatestRenewalOrderForOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 3150,
+        "column": 38
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 3158,
+        "column": 11
+      },
+      {
+        "callee": "changePatientAddressInReviveIfNecessary",
+        "module": "@/app/services/pharmacy-integration/revive/revive-patient-api",
+        "line": 3167,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3200,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3226,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3258,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 3286,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/orders-dbtype.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/orders/process-manual-order.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getSubscriptionByProduct"
-      ],
-      "@/app/utils/database/controller/products/products": [
-        "getPriceIdForProductVariant"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "createBalanceTransaction",
-        "refundStripeInvoiceWithAmount",
-        "updateStripeProduct",
-        "updateStripeSubscriptionImmediately"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "updateStatusTagToReview"
-      ],
-      "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api": [
-        "createOrderDataAudit"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "updatePrescriptionSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "createRenewalOrderWithPayload",
-        "getLatestRenewalOrderByCustomerAndProduct"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/create-order-utils": [
-        "getNextRenewalOrderId"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getSubscriptionByProduct",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 47,
+        "column": 32
+      },
+      {
+        "callee": "getPriceIdForProductVariant",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 69,
+        "column": 32
+      },
+      {
+        "callee": "refundStripeInvoiceWithAmount",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 137,
+        "column": 15
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 150,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeSubscriptionImmediately",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 155,
+        "column": 19
+      },
+      {
+        "callee": "createBalanceTransaction",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 162,
+        "column": 15
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 178,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeSubscriptionImmediately",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 183,
+        "column": 19
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 204,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeSubscriptionImmediately",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 209,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 227,
+        "column": 19
+      },
+      {
+        "callee": "updateStatusTagToReview",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 228,
+        "column": 19
+      },
+      {
+        "callee": "createOrderDataAudit",
+        "module": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 232,
+        "column": 19
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 256,
+        "column": 11
+      },
+      {
+        "callee": "getLatestRenewalOrderByCustomerAndProduct",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 290,
+        "column": 38
+      },
+      {
+        "callee": "getNextRenewalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/orders/create-order-utils",
+        "line": 299,
+        "column": 34
+      },
+      {
+        "callee": "createRenewalOrderWithPayload",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 325,
+        "column": 18
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getMonthsIntoRenewalOrderSubscription",
-        "isRenewalOrder"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "lodash": [
-        "isEmpty"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getOrderById"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 38,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 64,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 89,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 138,
+        "column": 22
+      },
+      {
+        "callee": "isRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 147,
+        "column": 16
+      },
+      {
+        "callee": "getMonthsIntoRenewalOrderSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 149,
+        "column": 30
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 173,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 176,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 180,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 211,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 231,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 250,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 271,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 296,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 312,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 329,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 352,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 364,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 375,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 387,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 402,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 434,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 462,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 487,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 512,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 534,
+        "column": 22
+      },
+      {
+        "callee": "getOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 562,
+        "column": 62
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 607,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 635,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 664,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 693,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 716,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 738,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 759,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 786,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 808,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 850,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 873,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 903,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history-types.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 13,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 22,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 45,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_combined_wl_answers_temp/patient_combined_wl_answers_temp_api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_document_uploads/patient_document_uploads.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 32,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 50,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_providers/patient-providers.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 66,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_weight_audit/patient-weight-audit-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 17,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 34,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 36,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 73,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/patient_weight_audit/patient-weight-audit-database-type.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_error_audit/payment_error_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failure_audit/payment_failure_audit-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history": [
-        "logPatientAction"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 42,
+        "column": 22
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 48,
+        "column": 15
+      },
+      {
+        "callee": "logPatientAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient_action_history/patient-action-history",
+        "line": 63,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 119,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 176,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 201,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 232,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 260,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 291,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 319,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 350,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failure_audit/payment_failure_audit.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failure_tracker/payment_failure_tracker-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 27,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 82,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 108,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 129,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 148,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 172,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 196,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failure_tracker/payment_failure_tracker.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failure_tracker/payment_failure_tracker_enums.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/payment_failures/payment-failures.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 13,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 35,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/pharmacy-order-failures/pharmacy-order-failures.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 14,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
+  },
+  {
+    "source": "utils/unvalidatedUtils/database/controller/pharmacy_order_audit/pharmacy_order_audit.tsx",
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 20,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 50,
+        "column": 22
+      },
+      {
+        "callee": "extractRenewalOrderId",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 57,
+        "column": 27
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 81,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
+  },
+  {
+    "source": "utils/unvalidatedUtils/database/controller/prescription_script_audit/prescription_script_audit.tsx",
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 30,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscription_enums.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "updateOrderSubscriptionID"
-      ],
-      "@/app/services/pharmacy-integration/prescription-refill-count": [
-        "getRefillCount"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription",
-        "getSubscriptionDetails",
-        "updatePrescriptionSubscription"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "extendSubscriptionRenewalBy5Days",
-        "getStripeSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 23,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 46,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 82,
+        "column": 22
+      },
+      {
+        "callee": "updateOrderSubscriptionID",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 117,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 130,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 148,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 170,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 196,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 222,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 233,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 247,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 268,
+        "column": 22
+      },
+      {
+        "callee": "getRefillCount",
+        "module": "@/app/services/pharmacy-integration/prescription-refill-count",
+        "line": 270,
+        "column": 26
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 282,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 307,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 328,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 335,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 357,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 376,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 403,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 428,
+        "column": 22
+      },
+      {
+        "callee": "getSubscriptionDetails",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 447,
+        "column": 36
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 463,
+        "column": 11
+      },
+      {
+        "callee": "getSubscriptionDetails",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 471,
+        "column": 36
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 514,
+        "column": 38
+      },
+      {
+        "callee": "extendSubscriptionRenewalBy5Days",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 525,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 532,
+        "column": 22
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 553,
+        "column": 32
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 559,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/product_variants/product_variants.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data": [
-        "getEmpowerCatalogObject"
-      ],
-      "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data": [
-        "getHallandaleCatalogObject"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 52,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 74,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 97,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 125,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 161,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 183,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 207,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 228,
+        "column": 22
+      },
+      {
+        "callee": "getEmpowerCatalogObject",
+        "module": "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data",
+        "line": 329,
+        "column": 38
+      },
+      {
+        "callee": "getHallandaleCatalogObject",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data",
+        "line": 359,
+        "column": 41
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/products/products.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 13,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 61,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 81,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 97,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 120,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 143,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 282,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 348,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 372,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 413,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/profiles/profiles-database-type.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/profiles/profiles.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "checkForExistingOrderV2",
-        "getIncompleteGlobalWLOrderPostHrefSwap"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "identifyUser"
-      ],
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getLatestRenewalOrderForOriginalOrderId",
-        "updateRenewalOrder"
-      ],
-      "@/app/utils/functions/renewal-orders/renewal-orders": [
-        "getOrderStatusDetails"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 20,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 42,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 63,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 81,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 103,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 125,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 139,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 160,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 162,
+        "column": 23
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 182,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 184,
+        "column": 23
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 204,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 228,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 256,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 258,
+        "column": 23
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 282,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 302,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 331,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 351,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 374,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 395,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 415,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 436,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 462,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 497,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 522,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 551,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 586,
+        "column": 22
+      },
+      {
+        "callee": "getIncompleteGlobalWLOrderPostHrefSwap",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 611,
+        "column": 19
+      },
+      {
+        "callee": "checkForExistingOrderV2",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 615,
+        "column": 19
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 645,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 673,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 733,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 757,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 779,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 806,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 841,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 880,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 906,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 952,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 979,
+        "column": 22
+      },
+      {
+        "callee": "identifyUser",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 999,
+        "column": 15
+      },
+      {
+        "callee": "getLatestRenewalOrderForOriginalOrderId",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 1006,
+        "column": 19
+      },
+      {
+        "callee": "getOrderStatusDetails",
+        "module": "@/app/utils/functions/renewal-orders/renewal-orders",
+        "line": 1012,
+        "column": 32
+      },
+      {
+        "callee": "identifyUser",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 1016,
+        "column": 15
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 1022,
+        "column": 19
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 1028,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1069,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 1072,
+        "column": 27
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/provider_activity_audit/provider_activity_audit-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 104,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 123,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 125,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 160,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 184,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 341,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 498,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 527,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 551,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 590,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 607,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 625,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 643,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 661,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 682,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 736,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 827,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/provider_activity_audit/provider_activity_audit.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/providers/providers-api.ts",
-    "calls": {
-      "@/app/utils/actions/auth/session-reader": [
-        "getCurrentUserId",
-        "readUserSession"
-      ],
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient",
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 17,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 19,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 37,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 54,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 71,
+        "column": 28
+      },
+      {
+        "callee": "getCurrentUserId",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 73,
+        "column": 26
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 92,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 113,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 138,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 161,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 180,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/providers/providers-type.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/actions/auth/session-reader": [
-        "readUserSession"
-      ],
-      "utils/unvalidatedUtils/database/controller/action-items/action-items-actions": [
-        "getAllActionsItemsForPatientWithSession"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getAllGLP1OrdersForProduct",
-        "getAllGLP1RenewalOrdersForProduct"
-      ],
-      "utils/unvalidatedUtils/actions/prescription-subscriptions/prescription-subscriptions-actions": [
-        "getAllGLP1SubscriptionsForProduct"
-      ],
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isGLP1Product"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 45,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 75,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 96,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 114,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 135,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 190,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 210,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 241,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 271,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 310,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 338,
+        "column": 26
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 404,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 432,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 475,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 499,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 520,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 532,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 588,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 684,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 711,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 747,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "utils/unvalidatedUtils/actions/auth/session-reader",
+        "line": 751,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 786,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "utils/unvalidatedUtils/actions/auth/session-reader",
+        "line": 790,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 815,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 836,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 855,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 880,
+        "column": 22
+      },
+      {
+        "callee": "getAllActionsItemsForPatientWithSession",
+        "module": "utils/unvalidatedUtils/database/controller/action-items/action-items-actions",
+        "line": 881,
+        "column": 32
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 961,
+        "column": 22
+      },
+      {
+        "callee": "getAllGLP1OrdersForProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 963,
+        "column": 26
+      },
+      {
+        "callee": "getAllGLP1RenewalOrdersForProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 964,
+        "column": 33
+      },
+      {
+        "callee": "getAllGLP1SubscriptionsForProduct",
+        "module": "utils/unvalidatedUtils/actions/prescription-subscriptions/prescription-subscriptions-actions",
+        "line": 965,
+        "column": 33
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 997,
+        "column": 13
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 1001,
+        "column": 21
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 1091,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 1129,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/questionnaires/questionnaire_sessions.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "updateOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/action-items/action-items-actions": [
-        "updateActionItem"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 36,
+        "column": 26
+      },
+      {
+        "callee": "updateOrder",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 54,
+        "column": 43
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 74,
+        "column": 26
+      },
+      {
+        "callee": "updateActionItem",
+        "module": "utils/unvalidatedUtils/database/controller/action-items/action-items-actions",
+        "line": 92,
+        "column": 43
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 109,
+        "column": 26
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/questionnaires/supabase_questionnaire_types.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/renewal_order_audit/renewal_order_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getBaseOrderById",
-        "getFirstCompletedOrderCreatedDate",
-        "getOrderById",
-        "getOrderIdByPatientIdAndProductHref"
-      ],
-      "@/app/utils/functions/renewal-orders/renewal-orders": [
-        "getFinalReviewStartsDate"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "forwardOrderToEngineering"
-      ],
-      "@/app/utils/functions/client-utils": [
-        "extractRenewalOrderId"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ],
-      "utils/unvalidatedUtils/database/controller/admin_order_cancel_audit/admin-order-cancel-audit": [
-        "insertAuditIntoAdministrativeCancelTable"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription",
-        "safeCancelSubscription"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "@/app/utils/functions/pricing": [
-        "isGLP1Product"
-      ],
-      "@/app/utils/functions/dates": [
-        "convertEpochToDate"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/containers/utils/intake-helpers": [
-        "getDaysBetweenDates"
-      ],
-      "utils/unvalidatedUtils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 53,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 98,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 120,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 144,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 179,
+        "column": 22
+      },
+      {
+        "callee": "getOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 197,
+        "column": 43
+      },
+      {
+        "callee": "getFinalReviewStartsDate",
+        "module": "@/app/utils/functions/renewal-orders/renewal-orders",
+        "line": 218,
+        "column": 34
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 241,
+        "column": 22
+      },
+      {
+        "callee": "getOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 242,
+        "column": 46
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 249,
+        "column": 15
+      },
+      {
+        "callee": "getFinalReviewStartsDate",
+        "module": "@/app/utils/functions/renewal-orders/renewal-orders",
+        "line": 274,
+        "column": 34
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 306,
+        "column": 22
+      },
+      {
+        "callee": "getOrderIdByPatientIdAndProductHref",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 325,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 344,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 368,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 391,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 423,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 448,
+        "column": 22
+      },
+      {
+        "callee": "extractRenewalOrderId",
+        "module": "@/app/utils/functions/client-utils",
+        "line": 481,
+        "column": 9
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 489,
+        "column": 31
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 499,
+        "column": 31
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 508,
+        "column": 22
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 537,
+        "column": 32
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 541,
+        "column": 25
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 552,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 572,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 592,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 610,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 636,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 658,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 681,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 702,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 721,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 738,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 760,
+        "column": 22
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 788,
+        "column": 33
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 805,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 826,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 873,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 896,
+        "column": 22
+      },
+      {
+        "callee": "getFirstCompletedOrderCreatedDate",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 905,
+        "column": 41
+      },
+      {
+        "callee": "insertAuditIntoAdministrativeCancelTable",
+        "module": "utils/unvalidatedUtils/database/controller/admin_order_cancel_audit/admin-order-cancel-audit",
+        "line": 943,
+        "column": 11
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 945,
+        "column": 32
+      },
+      {
+        "callee": "safeCancelSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 947,
+        "column": 31
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 954,
+        "column": 15
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 992,
+        "column": 22
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 1031,
+        "column": 36
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "@/app/utils/functions/pricing",
+        "line": 1037,
+        "column": 14
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 1043,
+        "column": 42
+      },
+      {
+        "callee": "convertEpochToDate",
+        "module": "@/app/utils/functions/dates",
+        "line": 1047,
+        "column": 22
+      },
+      {
+        "callee": "getDaysBetweenDates",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/intake-helpers",
+        "line": 1049,
+        "column": 35
+      },
+      {
+        "callee": "getOrderById",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 1122,
+        "column": 42
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "utils/unvalidatedUtils/database/controller/product_variants/product_variants",
+        "line": 1132,
+        "column": 32
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1149,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1178,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1227,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 1255,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/revive_pharmacy_patient_data/revive_pharamacy_patient_data_api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 19,
+        "column": 18
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 30,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/revive_pharmacy_patient_data/revive_pharmacy_patient_data.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/shipping_status_audit/shipping_status_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 5,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/shipping_tracking_failed_audit/shipping-tracking-failed-audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/site-error-audit/site_error_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 17,
+        "column": 36
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/site-error-audit/site_error_identifiers.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/storage/face-pictures/face-picture-functions.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 29,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/storage/license-selfie/license-selfie-functions.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 9,
+        "column": 28
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 29,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/stripe_audit/stripe_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 8,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 32,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/subscription_status_audit/subscription_stauts_audit.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 11,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/controller/tasks/task-api.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "lodash": [
-        "isEmpty"
-      ],
-      "@/app/utils/actions/auth/session-reader": [
-        "readUserSession"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 10,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 28,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 56,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 75,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 86,
+        "column": 22
+      },
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 104,
+        "column": 9
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 125,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 153,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 199,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 267,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 286,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 303,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 305,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 330,
+        "column": 22
+      },
+      {
+        "callee": "readUserSession",
+        "module": "@/app/utils/actions/auth/session-reader",
+        "line": 332,
+        "column": 27
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 359,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 380,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/schema.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/storage/lab-work-documents/lab-work-documents.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 8,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 31,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 77,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/storage/license-selfie/license-selfie.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 8,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 37,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 52,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/database/storage/skin-care-face-pictures/skin-care-face-uploads.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 6,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 37,
+        "column": 28
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/address-verification.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/annual-glp1/annual-glp1-controller.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getStripeSubscriptionIdFromSubscription"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 15,
+        "column": 34
+      },
+      {
+        "callee": "getStripeSubscriptionIdFromSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 24,
+        "column": 15
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 31,
+        "column": 38
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 60,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 98,
+        "column": 22
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 124,
+        "column": 34
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 155,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 170,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/annual-glp1/annual-glp1-mappings.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/annual-glp1/annual_record.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/auth/authorization/authorizaiton-helper.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/auth/password-reset/password-reset.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 7,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 26,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/clean-stale-orders/clean-stale-orders.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 43,
+        "column": 26
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/client-utils.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/coordinator-portal/time-tracker/coordinator-time-tracker-functions.ts",
-    "calls": {
-      "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api": [
-        "endSession",
-        "getCoordinatorActivityAuditCountsBetweenDates",
-        "getCoordinatorAutomaticSessionTimes",
-        "getCoordinatorSessionRecord"
-      ],
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "dayjs": [
-        "dayjs"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getCoordinatorSessionRecord",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 34,
+        "column": 47
+      },
+      {
+        "callee": "endSession",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 59,
+        "column": 23
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 75,
+        "column": 22
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 115,
+        "column": 18
+      },
+      {
+        "callee": "getCoordinatorAutomaticSessionTimes",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 122,
+        "column": 36
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 186,
+        "column": 23
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 187,
+        "column": 21
+      },
+      {
+        "callee": "getCoordinatorActivityAuditCountsBetweenDates",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 195,
+        "column": 27
+      },
+      {
+        "callee": "getCoordinatorAutomaticSessionTimes",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 205,
+        "column": 40
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 262,
+        "column": 23
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 263,
+        "column": 21
+      },
+      {
+        "callee": "getCoordinatorAutomaticSessionTimes",
+        "module": "@/app/utils/database/controller/coordinator_activity_audit/coordinator_activity_audit-api",
+        "line": 270,
+        "column": 36
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/coordinator-portal/time-tracker/coordinator-time-tracker-types.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/csv_convert_download.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/customerio/utils.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/dates.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/formatting.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/generateUUIDFromStringAndNumber.ts",
-    "calls": {
-      "crypto": [
-        "createHash"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createHash",
+        "module": "crypto",
+        "line": 9,
+        "column": 18
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/intake-route-controller.ts",
-    "calls": {
-      "lodash": [
-        "isEmpty"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "isEmpty",
+        "module": "lodash",
+        "line": 472,
+        "column": 10
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/isTransitionScreen.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/BaseJobSchedulerHandler.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/job-scheduler/job-scheduler-actions": [
-        "auditJobScheduler",
-        "handleJobFailure",
-        "handleJobSuccess"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "handleJobSuccess",
+        "module": "utils/unvalidatedUtils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 50,
+        "column": 19
+      },
+      {
+        "callee": "handleJobFailure",
+        "module": "utils/unvalidatedUtils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 53,
+        "column": 19
+      },
+      {
+        "callee": "auditJobScheduler",
+        "module": "utils/unvalidatedUtils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 66,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/JobSchedulerFactory.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/BaseCommJobHandler.ts",
-    "calls": {
-      "@/app/utils/database/controller/job-scheduler/job-scheduler-actions": [
-        "createNewCommsJob"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createNewCommsJob",
+        "module": "@/app/utils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 109,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/IDAndSelfieCheckJobHandler.ts",
-    "calls": {
-      "@/app/utils/database/controller/profiles/profiles": [
-        "getIDVerificationData"
-      ],
-      "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction"
-      ],
-      "@/app/utils/database/controller/orders/orders-api": [
-        "getBaseOrderById"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "shouldSendIDVerification"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getIDVerificationData",
+        "module": "@/app/utils/database/controller/profiles/profiles",
+        "line": 31,
+        "column": 23
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 34,
+        "column": 23
+      },
+      {
+        "callee": "getBaseOrderById",
+        "module": "@/app/utils/database/controller/orders/orders-api",
+        "line": 44,
+        "column": 41
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 57,
+        "column": 27
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 67,
+        "column": 27
+      },
+      {
+        "callee": "shouldSendIDVerification",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 78,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/RenewalAutoshipJobHandler.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/RenewalValidationJobHandler.ts",
-    "calls": {
-      "@/app/utils/database/controller/renewal_orders/renewal_orders": [
-        "getLatestRenewalOrderForSubscription"
-      ],
-      "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "addOrRemoveStatusFlags"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ],
-      "@/app/utils/database/controller/order_data_audit/order_data_audit_api": [
-        "createOrderDataAudit"
-      ],
-      "@/app/utils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "@/app/utils/classes/DosingChangeController/DosageChangeEquivalenceMap": [
-        "getDosageEquivalenceCodeFromVariantIndex"
-      ],
-      "@/app/utils/database/controller/profiles/profiles": [
-        "getUserState"
-      ],
-      "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping": [
-        "convertBundleVariantToSingleVariant"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "updateStripeProduct"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getLatestRenewalOrderForSubscription",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 50,
+        "column": 36
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 62,
+        "column": 23
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 67,
+        "column": 23
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 73,
+        "column": 23
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 79,
+        "column": 44
+      },
+      {
+        "callee": "createOrderDataAudit",
+        "module": "@/app/utils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 99,
+        "column": 15
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 184,
+        "column": 45
+      },
+      {
+        "callee": "getDosageEquivalenceCodeFromVariantIndex",
+        "module": "@/app/utils/classes/DosingChangeController/DosageChangeEquivalenceMap",
+        "line": 202,
+        "column": 33
+      },
+      {
+        "callee": "getUserState",
+        "module": "@/app/utils/database/controller/profiles/profiles",
+        "line": 223,
+        "column": 40
+      },
+      {
+        "callee": "convertBundleVariantToSingleVariant",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 230,
+        "column": 31
+      },
+      {
+        "callee": "createOrderDataAudit",
+        "module": "@/app/utils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 236,
+        "column": 15
+      },
+      {
+        "callee": "updateStripeProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 255,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/SendPrescriptionJobHandler.ts",
-    "calls": {
-      "utils/unvalidatedUtils/functions/client-utils": [
-        "getOrderTypeFromOrderId"
-      ],
-      "@/app/utils/database/controller/renewal_orders/renewal_orders": [
-        "getRenewalOrder"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getOrderTypeFromOrderId",
+        "module": "utils/unvalidatedUtils/functions/client-utils",
+        "line": 16,
+        "column": 27
+      },
+      {
+        "callee": "getRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 24,
+        "column": 36
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 32,
+        "column": 36
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/job-scheduler/jobs/StripeInvoicePaidJobHandler.ts",
-    "calls": {
-      "@/app/utils/database/controller/renewal_orders/renewal_orders": [
-        "createUpcomingRenewalOrderWithRenewalOrderId",
-        "getLatestRenewalOrderForSubscription",
-        "getRenewalOrder",
-        "updateRenewalOrder",
-        "updateRenewalOrderStatus"
-      ],
-      "@/app/utils/actions/subscriptions/subscription-actions": [
-        "getPrescriptionSubscription",
-        "updatePrescriptionSubscription"
-      ],
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isWeightlossProduct"
-      ],
-      "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction",
-        "forwardOrderToEngineering",
-        "updateStatusTagToResolved"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getLastInvoiceBeforeRenewal",
-        "getStripeInvoice",
-        "updateStripeProduct"
-      ],
-      "@/app/utils/database/controller/products/products": [
-        "getSingleProductVariantCadence",
-        "getVariantIndexByPriceIdV2"
-      ],
-      "@/app/utils/database/controller/action-items/action-items-actions": [
-        "getLastestActionItemForProduct",
-        "updateActionItem"
-      ],
-      "@/app/utils/database/controller/order_data_audit/order_data_audit_api": [
-        "createOrderDataAudit",
-        "getLatestDosageSelectionForRenewalOrder"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map": [
-        "getEligiblePharmacy"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/intake-response-column/adjust-dosing-dialog/dosing-mappings": [
-        "getMonthlyGlp1Dosage"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "triggerEvent"
-      ],
-      "@/app/services/pharmacy-integration/curexa/curexa-actions": [
-        "sendRenewalCurexaOrder"
-      ],
-      "@/app/services/pharmacy-integration/gogomeds/ggm-actions": [
-        "sendGGMRenewalRequest"
-      ],
-      "@/app/services/pharmacy-integration/tmc/tmc-actions": [
-        "sendRenewalOrderToTMC"
-      ],
-      "@/app/services/pharmacy-integration/empower/send-script": [
-        "sendRenewalOrderToEmpower"
-      ],
-      "utils/unvalidatedUtils/functions/renewal-orders/renewal-orders": [
-        "getOrderStatusDetails"
-      ],
-      "@/app/utils/database/controller/product_variants/product_variants": [
-        "getPriceDataRecordWithVariant"
-      ],
-      "@/app/utils/actions/check-up/check-up-actions": [
-        "getLastCheckInFormSubmission",
-        "isWithinLastThreeMonths"
-      ],
-      "@/app/utils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "@/app/utils/database/controller/job-scheduler/job-scheduler-actions": [
-        "createNewAutoRenewalJob",
-        "createNewSendPrescriptionJob"
-      ],
-      "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping": [
-        "convertBundleVariantToSingleVariant",
-        "shouldConvertBundleSubscriptionToMonthly"
-      ],
-      "@/app/utils/classes/DosingChangeController/DosageChangeEquivalenceMap": [
-        "getDosageEquivalenceCodeFromVariantIndex"
-      ],
-      "@/app/utils/database/controller/profiles/profiles": [
-        "getUserState"
-      ],
-      "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "addOrRemoveStatusFlags"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 126,
+        "column": 34
+      },
+      {
+        "callee": "getPrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 134,
+        "column": 36
+      },
+      {
+        "callee": "isWeightlossProduct",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 144,
+        "column": 13
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 198,
+        "column": 23
+      },
+      {
+        "callee": "getStripeInvoice",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 209,
+        "column": 38
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 214,
+        "column": 19
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 237,
+        "column": 19
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 248,
+        "column": 52
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 271,
+        "column": 19
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 288,
+        "column": 19
+      },
+      {
+        "callee": "getLastestActionItemForProduct",
+        "module": "@/app/utils/database/controller/action-items/action-items-actions",
+        "line": 296,
+        "column": 40
+      },
+      {
+        "callee": "updateActionItem",
+        "module": "@/app/utils/database/controller/action-items/action-items-actions",
+        "line": 302,
+        "column": 19
+      },
+      {
+        "callee": "getLatestDosageSelectionForRenewalOrder",
+        "module": "@/app/utils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 317,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 334,
+        "column": 30
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 341,
+        "column": 33
+      },
+      {
+        "callee": "getSingleProductVariantCadence",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 347,
+        "column": 38
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 364,
+        "column": 19
+      },
+      {
+        "callee": "getMonthlyGlp1Dosage",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/intake-response-column/adjust-dosing-dialog/dosing-mappings",
+        "line": 396,
+        "column": 28
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 448,
+        "column": 19
+      },
+      {
+        "callee": "updateRenewalOrderStatus",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 453,
+        "column": 19
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 473,
+        "column": 19
+      },
+      {
+        "callee": "createUpcomingRenewalOrderWithRenewalOrderId",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 487,
+        "column": 15
+      },
+      {
+        "callee": "getLatestRenewalOrderForSubscription",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 491,
+        "column": 39
+      },
+      {
+        "callee": "sendRenewalCurexaOrder",
+        "module": "@/app/services/pharmacy-integration/curexa/curexa-actions",
+        "line": 504,
+        "column": 23
+      },
+      {
+        "callee": "sendGGMRenewalRequest",
+        "module": "@/app/services/pharmacy-integration/gogomeds/ggm-actions",
+        "line": 507,
+        "column": 23
+      },
+      {
+        "callee": "sendRenewalOrderToTMC",
+        "module": "@/app/services/pharmacy-integration/tmc/tmc-actions",
+        "line": 510,
+        "column": 23
+      },
+      {
+        "callee": "sendRenewalOrderToEmpower",
+        "module": "@/app/services/pharmacy-integration/empower/send-script",
+        "line": 513,
+        "column": 23
+      },
+      {
+        "callee": "getOrderStatusDetails",
+        "module": "utils/unvalidatedUtils/functions/renewal-orders/renewal-orders",
+        "line": 529,
+        "column": 36
+      },
+      {
+        "callee": "getLastInvoiceBeforeRenewal",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 534,
+        "column": 42
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 555,
+        "column": 43
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 560,
+        "column": 47
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 565,
+        "column": 44
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 570,
+        "column": 40
+      },
+      {
+        "callee": "getLastCheckInFormSubmission",
+        "module": "@/app/utils/actions/check-up/check-up-actions",
+        "line": 611,
+        "column": 43
+      },
+      {
+        "callee": "isWithinLastThreeMonths",
+        "module": "@/app/utils/actions/check-up/check-up-actions",
+        "line": 617,
+        "column": 33
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "@/app/utils/actions/provider/patient-overview",
+        "line": 637,
+        "column": 27
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 648,
+        "column": 34
+      },
+      {
+        "callee": "createNewAutoRenewalJob",
+        "module": "@/app/utils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 653,
+        "column": 23
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 657,
+        "column": 23
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 667,
+        "column": 23
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 697,
+        "column": 45
+      },
+      {
+        "callee": "shouldConvertBundleSubscriptionToMonthly",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 702,
+        "column": 31
+      },
+      {
+        "callee": "getDosageEquivalenceCodeFromVariantIndex",
+        "module": "@/app/utils/classes/DosingChangeController/DosageChangeEquivalenceMap",
+        "line": 719,
+        "column": 37
+      },
+      {
+        "callee": "getUserState",
+        "module": "@/app/utils/database/controller/profiles/profiles",
+        "line": 732,
+        "column": 44
+      },
+      {
+        "callee": "convertBundleVariantToSingleVariant",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 741,
+        "column": 35
+      },
+      {
+        "callee": "createOrderDataAudit",
+        "module": "@/app/utils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 747,
+        "column": 19
+      },
+      {
+        "callee": "updateStripeProduct",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 767,
+        "column": 19
+      },
+      {
+        "callee": "forwardOrderToEngineering",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 801,
+        "column": 23
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 807,
+        "column": 19
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 812,
+        "column": 19
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 817,
+        "column": 19
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 891,
+        "column": 27
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 941,
+        "column": 27
+      },
+      {
+        "callee": "addOrRemoveStatusFlags",
+        "module": "@/app/utils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 946,
+        "column": 27
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 961,
+        "column": 31
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 966,
+        "column": 31
+      },
+      {
+        "callee": "getLastInvoiceBeforeRenewal",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 981,
+        "column": 35
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 993,
+        "column": 54
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 1009,
+        "column": 35
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 1019,
+        "column": 39
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 1024,
+        "column": 55
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1032,
+        "column": 35
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 1064,
+        "column": 53
+      },
+      {
+        "callee": "shouldConvertBundleSubscriptionToMonthly",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 1070,
+        "column": 25
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 1095,
+        "column": 51
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 1100,
+        "column": 35
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1105,
+        "column": 31
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 1116,
+        "column": 31
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1126,
+        "column": 31
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 1133,
+        "column": 27
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 1154,
+        "column": 53
+      },
+      {
+        "callee": "shouldConvertBundleSubscriptionToMonthly",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 1160,
+        "column": 25
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 1185,
+        "column": 51
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 1190,
+        "column": 35
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1195,
+        "column": 31
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 1206,
+        "column": 31
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1216,
+        "column": 31
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 1223,
+        "column": 27
+      },
+      {
+        "callee": "getVariantIndexByPriceIdV2",
+        "module": "@/app/utils/database/controller/products/products",
+        "line": 1244,
+        "column": 53
+      },
+      {
+        "callee": "shouldConvertBundleSubscriptionToMonthly",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 1250,
+        "column": 25
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 1274,
+        "column": 51
+      },
+      {
+        "callee": "getPriceDataRecordWithVariant",
+        "module": "@/app/utils/database/controller/product_variants/product_variants",
+        "line": 1279,
+        "column": 35
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1284,
+        "column": 31
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 1295,
+        "column": 31
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1305,
+        "column": 31
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 1312,
+        "column": 27
+      },
+      {
+        "callee": "createNewAutoRenewalJob",
+        "module": "@/app/utils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 1336,
+        "column": 15
+      },
+      {
+        "callee": "createNewSendPrescriptionJob",
+        "module": "@/app/utils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 1338,
+        "column": 15
+      },
+      {
+        "callee": "updatePrescriptionSubscription",
+        "module": "@/app/utils/actions/subscriptions/subscription-actions",
+        "line": 1340,
+        "column": 15
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1344,
+        "column": 15
+      },
+      {
+        "callee": "updateStatusTagToResolved",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 1349,
+        "column": 15
+      },
+      {
+        "callee": "createNewSendPrescriptionJob",
+        "module": "@/app/utils/database/controller/job-scheduler/job-scheduler-actions",
+        "line": 1360,
+        "column": 15
+      },
+      {
+        "callee": "updateRenewalOrder",
+        "module": "@/app/utils/database/controller/renewal_orders/renewal_orders",
+        "line": 1362,
+        "column": 15
+      },
+      {
+        "callee": "updateStatusTagToResolved",
+        "module": "@/app/utils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 1367,
+        "column": 15
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/jobs/JobsFactory.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getMonthsIntoRenewalOrderSubscription",
-        "getRenewalOrder",
-        "isRenewalOrder"
-      ],
-      "utils/unvalidatedUtils/functions/jobs/jobs": [
-        "getReviewStatusTagForRenewalOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api": [
-        "createUserStatusTagWAction"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "shouldSendIDVerification",
-        "triggerEvent"
-      ],
-      "@/app/services/mixpanel/mixpanel-utils": [
-        "retryVerifyMixpanelEvent"
-      ],
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isGLP1Product"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "isRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 83,
+        "column": 33
+      },
+      {
+        "callee": "getReviewStatusTagForRenewalOrder",
+        "module": "utils/unvalidatedUtils/functions/jobs/jobs",
+        "line": 87,
+        "column": 31
+      },
+      {
+        "callee": "getRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 106,
+        "column": 40
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 116,
+        "column": 19
+      },
+      {
+        "callee": "shouldSendIDVerification",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 136,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 143,
+        "column": 19
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 148,
+        "column": 15
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 154,
+        "column": 19
+      },
+      {
+        "callee": "triggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 159,
+        "column": 15
+      },
+      {
+        "callee": "retryVerifyMixpanelEvent",
+        "module": "@/app/services/mixpanel/mixpanel-utils",
+        "line": 172,
+        "column": 19
+      },
+      {
+        "callee": "getRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 186,
+        "column": 36
+      },
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 193,
+        "column": 14
+      },
+      {
+        "callee": "getMonthsIntoRenewalOrderSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 199,
+        "column": 33
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 204,
+        "column": 23
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 214,
+        "column": 23
+      },
+      {
+        "callee": "createUserStatusTagWAction",
+        "module": "utils/unvalidatedUtils/database/controller/patient-status-tags/patient-status-tags-api",
+        "line": 225,
+        "column": 19
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/jobs/jobs.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getMonthsIntoRenewalOrderSubscription"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getMonthsIntoRenewalOrderSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 13,
+        "column": 26
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/meta-events.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/patient-portal/patient-portal-utils.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders": [
-        "getPriceForRenewalOrder"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "getPriceForProduct"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getPriceForRenewalOrder",
+        "module": "utils/unvalidatedUtils/database/controller/renewal_orders/renewal_orders",
+        "line": 249,
+        "column": 31
+      },
+      {
+        "callee": "getPriceForProduct",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 251,
+        "column": 32
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-to-single-vial-converter.ts",
-    "calls": {
-      "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping": [
-        "convertBundleVariantToSingleVariant"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map": [
-        "getEligiblePharmacy"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2": [
-        "getQuestionAnswersForBMI"
-      ],
-      "@/app/utils/functions/prescription-scripts/empower-approval-script-generator": [
-        "generateEmpowerScript"
-      ],
-      "@/app/utils/functions/prescription-scripts/hallandale-approval-script-generator": [
-        "generateHallandaleScript"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical-notes": [
-        "getPatientAllergyData"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "@/app/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/hallandale/utils/hallandale-base64-pdf": [
-        "convertHallandaleOrderToBase64"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "convertBundleVariantToSingleVariant",
+        "module": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping",
+        "line": 31,
+        "column": 31
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 36,
+        "column": 22
+      },
+      {
+        "callee": "getQuestionAnswersForBMI",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2",
+        "line": 42,
+        "column": 35
+      },
+      {
+        "callee": "generateEmpowerScript",
+        "module": "@/app/utils/functions/prescription-scripts/empower-approval-script-generator",
+        "line": 44,
+        "column": 24
+      },
+      {
+        "callee": "generateHallandaleScript",
+        "module": "@/app/utils/functions/prescription-scripts/hallandale-approval-script-generator",
+        "line": 82,
+        "column": 24
+      },
+      {
+        "callee": "getEligiblePharmacy",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/containers/utils/approval-pharmacy-scripts/approval-pharmacy-product-map",
+        "line": 105,
+        "column": 20
+      },
+      {
+        "callee": "getQuestionAnswersForBMI",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2",
+        "line": 125,
+        "column": 35
+      },
+      {
+        "callee": "generateEmpowerScript",
+        "module": "@/app/utils/functions/prescription-scripts/empower-approval-script-generator",
+        "line": 127,
+        "column": 24
+      },
+      {
+        "callee": "getPatientAllergyData",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical-notes",
+        "line": 160,
+        "column": 15
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 162,
+        "column": 59
+      },
+      {
+        "callee": "generateHallandaleScript",
+        "module": "@/app/utils/functions/prescription-scripts/hallandale-approval-script-generator",
+        "line": 174,
+        "column": 32
+      },
+      {
+        "callee": "convertHallandaleOrderToBase64",
+        "module": "@/app/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/hallandale/utils/hallandale-base64-pdf",
+        "line": 183,
+        "column": 31
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/pharmacy-helpers/bundle-variant-index-mapping.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/boothwyn-script-generator.ts",
-    "calls": {
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api": [
-        "getResendCount"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 29,
+        "column": 53
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 33,
+        "column": 62
+      },
+      {
+        "callee": "getResendCount",
+        "module": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 44,
+        "column": 31
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/empower-approval-script-generator.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data": [
-        "getEmpowerCatalogObject"
-      ],
-      "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/empower/utils/bmi-diagnosis-functions": [
-        "getDiagnosisWithBMIData"
-      ],
-      "@/app/services/pharmacy-integration/empower/empower-catalog": [
-        "searchEmpowerItemCatalogByCode"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2": [
-        "getQuestionAnswersForBMI"
-      ],
-      "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api": [
-        "getResendCount"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getEmpowerCatalogObject",
+        "module": "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data",
+        "line": 115,
+        "column": 47
+      },
+      {
+        "callee": "getDiagnosisWithBMIData",
+        "module": "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/empower/utils/bmi-diagnosis-functions",
+        "line": 125,
+        "column": 26
+      },
+      {
+        "callee": "searchEmpowerItemCatalogByCode",
+        "module": "@/app/services/pharmacy-integration/empower/empower-catalog",
+        "line": 156,
+        "column": 41
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 210,
+        "column": 56
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 211,
+        "column": 48
+      },
+      {
+        "callee": "getQuestionAnswersForBMI",
+        "module": "utils/unvalidatedUtils/database/controller/clinical_notes/clinical_notes_v2",
+        "line": 215,
+        "column": 28
+      },
+      {
+        "callee": "getResendCount",
+        "module": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 221,
+        "column": 31
+      },
+      {
+        "callee": "getEmpowerCatalogObject",
+        "module": "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data",
+        "line": 319,
+        "column": 47
+      },
+      {
+        "callee": "getDiagnosisWithBMIData",
+        "module": "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/empower/utils/bmi-diagnosis-functions",
+        "line": 329,
+        "column": 26
+      },
+      {
+        "callee": "searchEmpowerItemCatalogByCode",
+        "module": "@/app/services/pharmacy-integration/empower/empower-catalog",
+        "line": 367,
+        "column": 41
+      },
+      {
+        "callee": "getEmpowerCatalogObject",
+        "module": "@/app/services/pharmacy-integration/empower/empower-variant-product-script-data",
+        "line": 498,
+        "column": 47
+      },
+      {
+        "callee": "getDiagnosisWithBMIData",
+        "module": "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/empower/utils/bmi-diagnosis-functions",
+        "line": 508,
+        "column": 26
+      },
+      {
+        "callee": "searchEmpowerItemCatalogByCode",
+        "module": "@/app/services/pharmacy-integration/empower/empower-catalog",
+        "line": 539,
+        "column": 41
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/hallandale-approval-script-generator.ts",
-    "calls": {
-      "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data": [
-        "getHallandaleCatalogObject"
-      ],
-      "@/app/services/pharmacy-integration/hallandale/hallandale-catalog": [
-        "searchHallandaleItemCatalogByCode"
-      ],
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/actions/provider/patient-overview": [
-        "getPatientInformationById"
-      ],
-      "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api": [
-        "getResendCount"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getHallandaleCatalogObject",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data",
+        "line": 77,
+        "column": 37
+      },
+      {
+        "callee": "searchHallandaleItemCatalogByCode",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-catalog",
+        "line": 84,
+        "column": 37
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 129,
+        "column": 56
+      },
+      {
+        "callee": "getPatientInformationById",
+        "module": "utils/unvalidatedUtils/actions/provider/patient-overview",
+        "line": 130,
+        "column": 48
+      },
+      {
+        "callee": "getResendCount",
+        "module": "utils/unvalidatedUtils/database/controller/order_data_audit/order_data_audit_api",
+        "line": 138,
+        "column": 31
+      },
+      {
+        "callee": "getHallandaleCatalogObject",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-variant-product-script-data",
+        "line": 225,
+        "column": 37
+      },
+      {
+        "callee": "searchHallandaleItemCatalogByCode",
+        "module": "@/app/services/pharmacy-integration/hallandale/hallandale-catalog",
+        "line": 232,
+        "column": 37
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/prescription-scripts-utils.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/revive-script-generator.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "@/app/services/pharmacy-integration/revive/revive-patient-api": [
-        "retrieveOrCreateAndRetrieveRevivePatientData"
-      ],
-      "uuid": [
-        "uuidv4"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 41,
+        "column": 62
+      },
+      {
+        "callee": "retrieveOrCreateAndRetrieveRevivePatientData",
+        "module": "@/app/services/pharmacy-integration/revive/revive-patient-api",
+        "line": 64,
+        "column": 19
+      },
+      {
+        "callee": "uuidv4",
+        "module": "uuid",
+        "line": 92,
+        "column": 52
+      },
+      {
+        "callee": "uuidv4",
+        "module": "uuid",
+        "line": 101,
+        "column": 42
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/prescription-scripts/tmc-approval-script-generator.ts",
-    "calls": {
-      "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/tmc/utils/tmc-medication-ids": [
-        "findMedicationByHref"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "findMedicationByHref",
+        "module": "utils/components/provider-portal/intake-view/v2/components/tab-column/prescribe/prescribe-windows/tmc/utils/tmc-medication-ids",
+        "line": 48,
+        "column": 31
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/pricing.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/provider-portal/intakes/provider-intake-utils.ts",
-    "calls": {
-      "utils/unvalidatedUtils/functions/pricing": [
-        "isGLP1Product"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "isGLP1Product",
+        "module": "utils/unvalidatedUtils/functions/pricing",
+        "line": 145,
+        "column": 9
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/provider-portal/messages/admin-message-center.ts",
-    "calls": {
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServerComponentClient"
-      ],
-      "@/app/utils/actions/message/message-actions": [
-        "getAllThreadsForUser"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 34,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 64,
+        "column": 22
+      },
+      {
+        "callee": "getAllThreadsForUser",
+        "module": "@/app/utils/actions/message/message-actions",
+        "line": 66,
+        "column": 30
+      },
+      {
+        "callee": "createSupabaseServerComponentClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 112,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/provider-portal/time-tracker/provider-time-tracker-functions.ts",
-    "calls": {
-      "@/app/utils/database/controller/provider_activity_audit/provider_activity_audit-api": [
-        "endSession",
-        "getProviderActivityAuditCountsBetweenDates",
-        "getProviderEstimatedPaymentBetweenDatesV2Verbose"
-      ],
-      "@/app/utils/actions/auth/server-signIn-signOut": [
-        "signOutUser"
-      ],
-      "@/app/utils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "dayjs": [
-        "dayjs"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "endSession",
+        "module": "@/app/utils/database/controller/provider_activity_audit/provider_activity_audit-api",
+        "line": 27,
+        "column": 11
+      },
+      {
+        "callee": "signOutUser",
+        "module": "@/app/utils/actions/auth/server-signIn-signOut",
+        "line": 28,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 39,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 61,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "@/app/utils/clients/supabaseServerClient",
+        "line": 88,
+        "column": 22
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 132,
+        "column": 18
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 207,
+        "column": 23
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 208,
+        "column": 21
+      },
+      {
+        "callee": "getProviderActivityAuditCountsBetweenDates",
+        "module": "@/app/utils/database/controller/provider_activity_audit/provider_activity_audit-api",
+        "line": 215,
+        "column": 36
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 285,
+        "column": 23
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 286,
+        "column": 21
+      },
+      {
+        "callee": "getProviderEstimatedPaymentBetweenDatesV2Verbose",
+        "module": "@/app/utils/database/controller/provider_activity_audit/provider_activity_audit-api",
+        "line": 305,
+        "column": 27
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 419,
+        "column": 23
+      },
+      {
+        "callee": "dayjs",
+        "module": "dayjs",
+        "line": 420,
+        "column": 21
+      },
+      {
+        "callee": "getProviderEstimatedPaymentBetweenDatesV2Verbose",
+        "module": "@/app/utils/database/controller/provider_activity_audit/provider_activity_audit-api",
+        "line": 428,
+        "column": 27
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/provider-portal/time-tracker/provider-time-tracker-types.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/renewal-orders/renewal-orders.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/rudderstack/rudderstack-utils.ts",
-    "calls": {
-      "@/app/utils/functions/utils": [
-        "getURL"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "getURL",
+        "module": "@/app/utils/functions/utils",
+        "line": 20,
+        "column": 26
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/split-shipment-glp1/split-shipment-glp1-controller.ts",
-    "calls": {
-      "utils/unvalidatedUtils/database/controller/orders/orders-api": [
-        "fetchOrderData"
-      ],
-      "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions": [
-        "getStripeSubscriptionIdFromSubscription"
-      ],
-      "@/app/(administration)/admin/stripe-api/stripe-api-actions": [
-        "getStripeSubscription"
-      ],
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 21,
+        "column": 34
+      },
+      {
+        "callee": "fetchOrderData",
+        "module": "utils/unvalidatedUtils/database/controller/orders/orders-api",
+        "line": 59,
+        "column": 34
+      },
+      {
+        "callee": "getStripeSubscriptionIdFromSubscription",
+        "module": "utils/unvalidatedUtils/database/controller/prescription_subscriptions/prescription_subscriptions",
+        "line": 68,
+        "column": 15
+      },
+      {
+        "callee": "getStripeSubscription",
+        "module": "@/app/(administration)/admin/stripe-api/stripe-api-actions",
+        "line": 75,
+        "column": 38
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 104,
+        "column": 22
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 141,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/split-shipment-glp1/split-shipment-variant-mappings.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/split-shipment-glp1/split_shipment_record.d.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/state-auth/utils.ts",
-    "calls": {}
+    "calls": [],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/functions/utils.ts",
-    "calls": {
-      "utils/unvalidatedUtils/clients/supabaseServerClient": [
-        "createSupabaseServiceClient"
-      ],
-      "@/app/services/customerio/customerioApiFactory": [
-        "batchTriggerEvent"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 29,
+        "column": 22
+      },
+      {
+        "callee": "batchTriggerEvent",
+        "module": "@/app/services/customerio/customerioApiFactory",
+        "line": 46,
+        "column": 11
+      },
+      {
+        "callee": "createSupabaseServiceClient",
+        "module": "utils/unvalidatedUtils/clients/supabaseServerClient",
+        "line": 54,
+        "column": 22
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/hooks/session-storage/useSessionStorage.ts",
-    "calls": {
-      "react": [
-        "useEffect",
-        "useState"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "useState",
+        "module": "react",
+        "line": 26,
+        "column": 43
+      },
+      {
+        "callee": "useEffect",
+        "module": "react",
+        "line": 56,
+        "column": 5
+      }
+    ],
+    "reachableEndpoints": []
   },
   {
     "source": "utils/unvalidatedUtils/hooks/storage/useDualStorage.ts",
-    "calls": {
-      "react": [
-        "useEffect",
-        "useState"
-      ]
-    }
+    "calls": [
+      {
+        "callee": "useState",
+        "module": "react",
+        "line": 11,
+        "column": 43
+      },
+      {
+        "callee": "useEffect",
+        "module": "react",
+        "line": 41,
+        "column": 5
+      }
+    ],
+    "reachableEndpoints": []
   }
 ]

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -59,3 +59,17 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
 | `global-wl-checkout` | `wl-checkout` | ~0.5d |
 | `global-wl-order-summary` | `order-summary` | ~0.5d |
 | `global-wl-whats-next` | `whats-next` | ~0.25d |
+
+### Timing Per Page – Other Funnels
+
+The legacy weight-loss funnel provides additional benchmarks that may help
+estimate work in related flows.
+
+| Page | Est. Time |
+| --- | --- |
+| `wl-intro` | ~0.25d |
+| `wl-goal-weight` | ~0.5d |
+| `wl-medications` | ~0.5d |
+| `wl-checkout` | ~0.5d |
+| `wl-order-summary` | ~0.5d |
+| `wl-whats-next` | ~0.25d |

--- a/scripts/audit/audit-utils.ts
+++ b/scripts/audit/audit-utils.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import ts from 'typescript';
 import { execSync } from 'child_process';
 
-const ROOT = path.join(__dirname, '..');
+const ROOT = path.join(__dirname, '..', '..');
 const SOURCE_DIR = path.join(ROOT, 'utils', 'unvalidatedUtils');
 
 interface ExportDetails {
@@ -82,36 +82,19 @@ walk(SOURCE_DIR);
 
 // map to compute reachable API endpoints using call-graph results
 try {
-  const callGraph: Array<{ source: string; calls: Record<string, string[]> }> = JSON.parse(
+  const callGraph: Array<{ source: string; reachableEndpoints?: string[] }> = JSON.parse(
     fs.readFileSync(path.join(ROOT, 'call-graph.json'), 'utf8')
   );
-  const adjacency = new Map<string, Set<string>>();
-  const apiSet = new Set<string>();
 
+  const map = new Map<string, string[]>();
   for (const entry of callGraph) {
-    adjacency.set(entry.source, new Set(Object.keys(entry.calls)));
-    if (entry.source.includes('/pages/api/') || entry.source.includes('/app/api/')) {
-      apiSet.add(entry.source);
+    if (entry.reachableEndpoints) {
+      map.set(entry.source, entry.reachableEndpoints);
     }
-  }
-
-  function collect(start: string, visited: Set<string> = new Set()): Set<string> {
-    if (visited.has(start)) return new Set();
-    visited.add(start);
-    const out = new Set<string>();
-    const calls = adjacency.get(start);
-    if (apiSet.has(start)) out.add(start);
-    if (calls) {
-      for (const mod of calls) {
-        if (apiSet.has(mod)) out.add(mod);
-        else collect(mod, visited).forEach(ep => out.add(ep));
-      }
-    }
-    return out;
   }
 
   for (const r of results) {
-    r.apiEndpoints = Array.from(collect(r.source));
+    r.apiEndpoints = map.get(r.source) ?? [];
   }
 } catch {
   console.warn('call-graph.json missing, apiEndpoints not computed');

--- a/scripts/audit/endpoint-trace.ts
+++ b/scripts/audit/endpoint-trace.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const ROOT = path.join(__dirname, '..');
+const ROOT = path.join(__dirname, '..', '..');
 const callGraphPath = path.join(ROOT, 'call-graph.json');
 
 interface GraphEntry {
@@ -50,7 +50,9 @@ function trace(start: string, visited: Set<string> = new Set()): Set<string> {
 
 const traces: Record<string, string[]> = {};
 for (const file of adjacency.keys()) {
-  traces[file] = Array.from(trace(file));
+  if (/page\.tsx?$/.test(file)) {
+    traces[file] = Array.from(trace(file));
+  }
 }
 
 fs.writeFileSync(path.join(ROOT, 'endpoint-trace.json'), JSON.stringify(traces, null, 2));


### PR DESCRIPTION
## Summary
- expand Global WL plan with timing for legacy pages
- update audit scripts to compute reachable API endpoints
- store endpoints per page with updated call graph

## Testing
- `npm run check:links`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6846158d34148328ba7fdcc113e8a4ac