### PR TITLE
Add API stubs for new weight loss funnel

### DIFF
--- a/bioverse-client/app/api/checkout/weight-loss/route.ts
+++ b/bioverse-client/app/api/checkout/weight-loss/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Finalizes an order for the global weight loss funnel.
+ * Expects JSON payload with order details.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    if (!data || !data.order_id) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    // TODO: implement checkout logic
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error('checkout POST error', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/bioverse-client/app/api/patient/goal-weight/route.ts
+++ b/bioverse-client/app/api/patient/goal-weight/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeQuestionnaireAnswer } from '@/app/utils/database/controller/questionnaires/questionnaire';
+
+/**
+ * API endpoint to record a patient's goal weight.
+ * Expects JSON: { user_id: string, weight: number }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { user_id, weight } = await req.json();
+    if (!user_id || typeof weight !== 'number') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    const QUESTION_ID_GOAL_WEIGHT = 2303;
+    await writeQuestionnaireAnswer(user_id, QUESTION_ID_GOAL_WEIGHT, { formData: [weight] }, 1);
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error('goal-weight POST error', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/bioverse-client/app/api/prescriptions/medication/route.ts
+++ b/bioverse-client/app/api/prescriptions/medication/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Stub endpoint to create a prescription record for the selected medication.
+ * Expects JSON: { user_id: string, medication: string }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const { user_id, medication } = await req.json();
+    if (!user_id || !medication) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    // TODO: implement persistence logic
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error('medication POST error', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/bioverse-client/app/api/products/weight-loss/route.ts
+++ b/bioverse-client/app/api/products/weight-loss/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const MEDICATION_OPTIONS = ['Ozempic', 'Mounjaro', 'Zepbound', 'BIOVERSE Weight Loss Capsule'];
+
+/**
+ * Returns medication options available for the global weight loss funnel.
+ */
+export async function GET() {
+  return NextResponse.json({ medications: MEDICATION_OPTIONS });
+}


### PR DESCRIPTION
## Summary
- scaffold API routes for Global WL funnel
- POST `/api/patient/goal-weight`
- GET `/api/products/weight-loss`
- POST `/api/prescriptions/medication`
- POST `/api/checkout/weight-loss`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684619a4ebdc83289d11c715887c1661