### PR TITLE
Add global weight-loss API routes

### DIFF
--- a/bioverse-client/app/api/checkout/weight-loss/route.ts
+++ b/bioverse-client/app/api/checkout/weight-loss/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { updateExistingOrderStatusAndExternalMetadataUsingId } from '@/app/utils/database/controller/orders/orders-api';
+import { OrderStatus } from '@/app/types/orders/order-types';
 
 /**
  * Finalizes an order for the global weight loss funnel.
@@ -10,7 +12,12 @@ export async function POST(req: NextRequest) {
     if (!data || !data.order_id) {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
     }
-    // TODO: implement checkout logic
+    await updateExistingOrderStatusAndExternalMetadataUsingId(
+      Number(data.order_id),
+      OrderStatus.ApprovedCardDownFinalized,
+      {}
+    );
+
     return NextResponse.json({ success: true });
   } catch (error: any) {
     console.error('checkout POST error', error);

--- a/bioverse-client/app/api/prescriptions/medication/route.ts
+++ b/bioverse-client/app/api/prescriptions/medication/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { writeQuestionnaireAnswer } from '@/app/utils/database/controller/questionnaires/questionnaire';
+import { getDoseSpotIframeUrlForGeneral } from '@/app/services/dosespot/v2/iframe/iframe-url-controller-v2';
+
+const QUESTION_ID_SELECTED_MEDICATION = 2357;
 
 /**
  * Stub endpoint to create a prescription record for the selected medication.
@@ -7,11 +11,20 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function POST(req: NextRequest) {
   try {
     const { user_id, medication } = await req.json();
-    if (!user_id || !medication) {
+    if (!user_id || typeof medication !== 'string') {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
     }
-    // TODO: implement persistence logic
-    return NextResponse.json({ success: true });
+
+    await writeQuestionnaireAnswer(
+      user_id,
+      QUESTION_ID_SELECTED_MEDICATION,
+      { formData: [medication] },
+      1
+    );
+
+    const { url } = await getDoseSpotIframeUrlForGeneral(user_id);
+
+    return NextResponse.json({ success: true, doseSpotUrl: url });
   } catch (error: any) {
     console.error('medication POST error', error);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- add GET /api/products/weight-loss to list medications
- implement POST /api/prescriptions/medication to save selection and link to DoseSpot
- finalize order via POST /api/checkout/weight-loss

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68461fefab708328b72356038b14ad13