### PR TITLE
Implement goal weight API calls

### DIFF
--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-goal-weight/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-goal-weight/page.tsx
@@ -4,15 +4,18 @@ import GoalWeight from '@/app/components/intake-v4/pages/goal-weight';
 import { readUserSession } from '@/app/utils/actions/auth/session-reader';
 
 interface Props {
-  params: { product: string };
-  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+    params: { product: string };
+    searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
 }
 
-export default async function GlobalWLGoalWeight({ params, searchParams }: Props) {
-  const user_id = (await readUserSession()).data.session?.user.id!;
-  return (
-    <>
-      <GoalWeight />
-    </>
-  );
+export default async function GlobalWLGoalWeight({
+    params,
+    searchParams,
+}: Props) {
+    const user_id = (await readUserSession()).data.session?.user.id!;
+    return (
+        <>
+            <GoalWeight userId={user_id} />
+        </>
+    );
 }

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-interactive/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-interactive/page.tsx
@@ -4,15 +4,18 @@ import InteractiveBMI from '@/app/components/intake-v4/pages/interactive-bmi';
 import { readUserSession } from '@/app/utils/actions/auth/session-reader';
 
 interface Props {
-  params: { product: string };
-  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+    params: { product: string };
+    searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
 }
 
-export default async function GlobalWLInteractive({ params, searchParams }: Props) {
-  const user_id = (await readUserSession()).data.session?.user.id!;
-  return (
-    <>
-      <InteractiveBMI />
-    </>
-  );
+export default async function GlobalWLInteractive({
+    params,
+    searchParams,
+}: Props) {
+    const user_id = (await readUserSession()).data.session?.user.id!;
+    return (
+        <>
+            <InteractiveBMI userId={user_id} />
+        </>
+    );
 }

--- a/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/goal-weight.tsx
@@ -13,7 +13,11 @@ import { getNextIntakeRoute } from '@/app/utils/functions/intake-route-controlle
 import { useState } from 'react';
 
 /** Collects the patient's target weight. */
-export default function GoalWeight() {
+interface Props {
+    userId: string;
+}
+
+export default function GoalWeight({ userId }: Props) {
     const router = useRouter();
     const url = useParams();
     const searchParams = useSearchParams();
@@ -22,14 +26,23 @@ export default function GoalWeight() {
     const { product_href } = getIntakeURLParams(url, searchParams);
     const [weight, setWeight] = useState(180);
 
-    const pushToNextRoute = () => {
+    const pushToNextRoute = async () => {
+        await fetch('/api/patient/goal-weight', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ user_id: userId, weight }),
+        });
         const nextRoute = getNextIntakeRoute(fullPath, product_href, search);
-        router.push(`/intake/prescriptions/${product_href}/${nextRoute}?${search}`);
+        router.push(
+            `/intake/prescriptions/${product_href}/${nextRoute}?${search}`,
+        );
     };
 
     return (
         <div className="flex flex-col items-center gap-4 mt-6">
-            <BioType className="inter-h5-question-header">What is your goal weight?</BioType>
+            <BioType className="inter-h5-question-header">
+                What is your goal weight?
+            </BioType>
             <input
                 type="number"
                 className="border p-2"

--- a/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/interactive-bmi.tsx
@@ -16,7 +16,11 @@ import { useState } from 'react';
  * Renders an interactive BMI comparison graph. Users can adjust their
  * current and goal weight to see projected BMI changes.
  */
-export default function InteractiveBMI() {
+interface Props {
+    userId: string;
+}
+
+export default function InteractiveBMI({ userId }: Props) {
     const router = useRouter();
     const url = useParams();
     const searchParams = useSearchParams();
@@ -31,9 +35,16 @@ export default function InteractiveBMI() {
     const currentBmi = currentWeight / (HEIGHT_M * HEIGHT_M);
     const goalBmi = goalWeight / (HEIGHT_M * HEIGHT_M);
 
-    const pushToNextRoute = () => {
+    const pushToNextRoute = async () => {
+        await fetch('/api/patient/goal-weight', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ user_id: userId, weight: goalWeight }),
+        });
         const nextRoute = getNextIntakeRoute(fullPath, product_href, search);
-        router.push(`/intake/prescriptions/${product_href}/${nextRoute}?${search}`);
+        router.push(
+            `/intake/prescriptions/${product_href}/${nextRoute}?${search}`,
+        );
     };
 
     return (
@@ -46,7 +57,9 @@ export default function InteractiveBMI() {
                         type="number"
                         className="border p-1 rounded"
                         value={currentWeight}
-                        onChange={(e) => setCurrentWeight(Number(e.target.value))}
+                        onChange={(e) =>
+                            setCurrentWeight(Number(e.target.value))
+                        }
                     />
                 </label>
                 <label className="flex flex-col text-sm">
@@ -60,8 +73,12 @@ export default function InteractiveBMI() {
                 </label>
             </div>
             <div className="h-40 w-full border flex flex-col items-center justify-center gap-2">
-                <span className="text-xs text-gray-600">Current BMI: {currentBmi.toFixed(1)}</span>
-                <span className="text-xs text-gray-600">Goal BMI: {goalBmi.toFixed(1)}</span>
+                <span className="text-xs text-gray-600">
+                    Current BMI: {currentBmi.toFixed(1)}
+                </span>
+                <span className="text-xs text-gray-600">
+                    Goal BMI: {goalBmi.toFixed(1)}
+                </span>
             </div>
             <AnimatedContinueButtonV3 onClick={pushToNextRoute} />
         </div>


### PR DESCRIPTION
## Summary
- capture user's goal weight via `/api/patient/goal-weight`
- pass userId to global weight loss pages
- persist goal weight in interactive BMI screen

## Integration Testing Done
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846201d28e083288c0878dfa25903dc