### PR TITLE
Add tests for endpoints and intake pages

### DIFF
--- a/__mocks__/next/navigation.ts
+++ b/__mocks__/next/navigation.ts
@@ -1,0 +1,4 @@
+export const useRouter = () => ({ push: jest.fn() })
+export const useParams = () => ({ product: 'weight-loss' })
+export const useSearchParams = () => new URLSearchParams()
+export const usePathname = () => '/intake/prescriptions/weight-loss/current'

--- a/__mocks__/next/server.ts
+++ b/__mocks__/next/server.ts
@@ -1,0 +1,4 @@
+export const NextResponse = {
+  json: (body: any, init?: any) => new Response(JSON.stringify(body), { status: init?.status ?? 200 })
+}
+export const NextRequest = function(){}

--- a/bioverse-client/__tests__/goal-weight.endpoint.test.ts
+++ b/bioverse-client/__tests__/goal-weight.endpoint.test.ts
@@ -1,0 +1,25 @@
+jest.mock('next/server', () => ({
+  NextResponse: { json: (b: any, init?: any) => new Response(JSON.stringify(b), { status: init?.status ?? 200 }) }
+}))
+import { POST } from '../app/api/patient/goal-weight/route'
+import { writeQuestionnaireAnswer } from '../app/utils/database/controller/questionnaires/questionnaire'
+
+jest.mock('../app/utils/database/controller/questionnaires/questionnaire', () => ({
+  writeQuestionnaireAnswer: jest.fn()
+}))
+
+describe('goal-weight endpoint', () => {
+  it('returns 400 on invalid payload', async () => {
+    const req: any = { json: jest.fn().mockResolvedValue({}) }
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('stores goal weight', async () => {
+    const req: any = { json: jest.fn().mockResolvedValue({ user_id: 'u1', weight: 200 }) }
+    const res = await POST(req)
+    expect(writeQuestionnaireAnswer).toHaveBeenCalledWith('u1', 2303, { formData: [200] }, 1)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true })
+  })
+})

--- a/bioverse-client/__tests__/intake-v4-pages.test.tsx
+++ b/bioverse-client/__tests__/intake-v4-pages.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import GoalWeight from '../app/components/intake-v4/pages/goal-weight'
+import MedicationOptions from '../app/components/intake-v4/pages/medication-options'
+import GlobalIntro from '../app/components/intake-v4/pages/global-intro'
+import GlobalCheckout from '../app/components/intake-v4/pages/global-checkout'
+import GlobalOrderSummary from '../app/components/intake-v4/pages/global-order-summary'
+import GlobalWLUpNext from '../app/components/intake-v4/pages/global-up-next'
+import GlobalWhatsNext from '../app/components/intake-v4/pages/global-whats-next'
+import InteractiveBMI from '../app/components/intake-v4/pages/interactive-bmi'
+
+jest.mock('@mui/material', () => ({
+  Button: (props: any) => <button {...props} />,
+}))
+
+const push = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  useParams: () => ({ product: 'weight-loss' }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/intake/prescriptions/weight-loss/current',
+}))
+
+jest.mock('../app/components/intake-v2/intake-functions', () => ({
+  getIntakeURLParams: () => ({ product_href: 'weight-loss' }),
+}))
+
+jest.mock('../app/utils/functions/intake-route-controller', () => ({
+  getNextIntakeRoute: () => 'next'
+}))
+
+describe('intake v4 pages', () => {
+  afterEach(() => { push.mockClear() })
+
+  it('goal weight navigates on continue', () => {
+    const { getByText } = render(<GoalWeight />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('medication options navigates on continue', () => {
+    const { getByText } = render(<MedicationOptions />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('interactive BMI navigates on continue', () => {
+    const { getByText } = render(<InteractiveBMI />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('global intro navigates on continue', () => {
+    const { getByText } = render(<GlobalIntro />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('global checkout navigates on continue', () => {
+    const { getByText } = render(<GlobalCheckout />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('global order summary navigates on continue', () => {
+    const { getByText } = render(<GlobalOrderSummary />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('global up next navigates on continue', () => {
+    const { getByText } = render(<GlobalWLUpNext />)
+    fireEvent.click(getByText('Continue'))
+    expect(push).toHaveBeenCalled()
+  })
+
+  it('global whats next renders text', () => {
+    const { getByText } = render(<GlobalWhatsNext />)
+    expect(getByText("What's Next")).toBeTruthy()
+  })
+})

--- a/bioverse-client/__tests__/medication.endpoints.test.ts
+++ b/bioverse-client/__tests__/medication.endpoints.test.ts
@@ -1,0 +1,29 @@
+jest.mock('next/server', () => ({
+  NextResponse: { json: (b: any, init?: any) => new Response(JSON.stringify(b), { status: init?.status ?? 200 }) }
+}))
+import { POST as createPrescription } from '../app/api/prescriptions/medication/route'
+import { GET as getOptions } from '../app/api/products/weight-loss/route'
+import axios from 'axios'
+jest.mock('../app/services/dosespot/v1/token/token', () => ({ getToken: jest.fn() }))
+
+jest.mock('axios')
+
+describe('medication endpoints', () => {
+  it('returns medication list', async () => {
+    const res = await getOptions()
+    await expect(res.json()).resolves.toEqual({ medications: ['Ozempic', 'Mounjaro', 'Zepbound', 'BIOVERSE Weight Loss Capsule'] })
+  })
+
+  it('rejects invalid payload', async () => {
+    const req: any = { json: jest.fn().mockResolvedValue({}) }
+    const res = await createPrescription(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('creates prescription with valid payload', async () => {
+    const req: any = { json: jest.fn().mockResolvedValue({ user_id: 'u1', medication: 'Ozempic' }) }
+    const res = await createPrescription(req)
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true })
+  })
+})


### PR DESCRIPTION
## Summary
- add mocks for Next.js modules
- add goal-weight API test
- add medication API tests
- add component tests for intake v4 pages

## Testing
- `npm test` *(fails: Cannot find module 'next/server')*

------
https://chatgpt.com/codex/tasks/task_b_68461ff4fb98832889b4433cb464bbaa