### PR TITLE
Update global WL doc

### DIFF
--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -32,8 +32,8 @@ Success is achieved when the new funnel matches the Figma designs, integrates wi
 - `global-wl-whats-next`
 - Each page mirrors the existing route pattern and renders a placeholder component from `components/intake-v4/pages/`.
 - Next we will flesh out the remaining screens using the same `app/(intake)/intake/prescriptions/[product]/<route>` structure. This keeps parity with the current weight‑loss routes and makes A/B testing easier. New files will follow the pattern of a thin server component that imports a client component from `components/intake-v4/pages/`.
-- Every route lives under the dynamic `[product]` folder so any `PRODUCT_HREF` value can load the funnel.
 - Route constants have been updated (`GLOBAL_WL_ROUTES`) so the intake controller knows about the new sequence.
+- All pages now reside under the dynamic `[product]` directory so any `PRODUCT_HREF` value automatically loads the funnel.
 - With the skeleton in place, the next step is fleshing out form logic and data wiring while keeping the same server component + client component split.
 
 ## Route Structure & Pages


### PR DESCRIPTION
## Summary
- note dynamic route parity for the new global weight-loss funnel

## Testing
- `npm run check:links` *(fails: ENETUNREACH)*
- `npm test` *(fails to run jest suites)*

------
https://chatgpt.com/codex/tasks/task_b_684627de6b4083289e8477dfca31af78