### PR TITLE
Add long version pages for global weight loss funnel

### DIFF
--- a/bioverse-client/__tests__/goal-weight.endpoint.test.ts
+++ b/bioverse-client/__tests__/goal-weight.endpoint.test.ts
@@ -1,3 +1,4 @@
+import { Response } from 'node-fetch'
 jest.mock('next/server', () => ({
   NextResponse: { json: (b: any, init?: any) => new Response(JSON.stringify(b), { status: init?.status ?? 200 }) }
 }))

--- a/bioverse-client/__tests__/medication.endpoints.test.ts
+++ b/bioverse-client/__tests__/medication.endpoints.test.ts
@@ -1,3 +1,4 @@
+import { Response } from 'node-fetch'
 jest.mock('next/server', () => ({
   NextResponse: { json: (b: any, init?: any) => new Response(JSON.stringify(b), { status: init?.status ?? 200 }) }
 }))
@@ -5,6 +6,10 @@ import { POST as createPrescription } from '../app/api/prescriptions/medication/
 import { GET as getOptions } from '../app/api/products/weight-loss/route'
 import axios from 'axios'
 jest.mock('../app/services/dosespot/v1/token/token', () => ({ getToken: jest.fn() }))
+jest.mock('../app/utils/clients/supabaseServerClient', () => ({
+  createSupabaseServerClient: jest.fn(() => ({ from: () => ({ insert: jest.fn().mockResolvedValue({}) }) })),
+  createSupabaseServiceClient: jest.fn(() => ({ from: () => ({ insert: jest.fn().mockResolvedValue({}) }) }))
+}))
 
 jest.mock('axios')
 

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-checkout/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-checkout/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalWLCheckout from '@/app/components/intake-v4/pages/global-checkout';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongCheckoutPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalWLCheckout />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-goal-weight/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-goal-weight/page.tsx
@@ -1,0 +1,16 @@
+'use server';
+
+import GoalWeight from '@/app/components/intake-v4/pages/goal-weight';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongGoalWeight({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <GoalWeight userId={user_id} />
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-interactive/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-interactive/page.tsx
@@ -1,0 +1,16 @@
+'use server';
+
+import InteractiveBMI from '@/app/components/intake-v4/pages/interactive-bmi';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongInteractive({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <InteractiveBMI userId={user_id} />
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-intro/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-intro/page.tsx
@@ -1,0 +1,21 @@
+'use server';
+
+import GlobalIntro from '@/app/components/intake-v4/pages/global-intro';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+    params: { product: string };
+    searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongIntroPage({
+    params,
+    searchParams,
+}: Props) {
+    const user_id = (await readUserSession()).data.session?.user.id!;
+    return (
+        <>
+            <GlobalIntro />
+        </>
+    );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-medications/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-medications/page.tsx
@@ -1,0 +1,16 @@
+'use server';
+
+import MedicationOptions from '@/app/components/intake-v4/pages/medication-options';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongMedications({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <MedicationOptions userId={user_id} />
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-order-summary/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-order-summary/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalOrderSummary from '@/app/components/intake-v4/pages/global-order-summary';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongOrderSummaryPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalOrderSummary />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-up-next/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-up-next/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalWLUpNext from '@/app/components/intake-v4/pages/global-up-next';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongUpNextPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalWLUpNext />
+    </>
+  );
+}

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-whats-next/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-long-whats-next/page.tsx
@@ -1,0 +1,18 @@
+'use server';
+
+import GlobalWhatsNext from '@/app/components/intake-v4/pages/global-whats-next';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+  params: { product: string };
+  searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLLongWhatsNextPage({ params, searchParams }: Props) {
+  const user_id = (await readUserSession()).data.session?.user.id!;
+  return (
+    <>
+      <GlobalWhatsNext />
+    </>
+  );
+}

--- a/bioverse-client/app/components/intake-v2/constants/route-constants.ts
+++ b/bioverse-client/app/components/intake-v2/constants/route-constants.ts
@@ -951,6 +951,23 @@ export const GLOBAL_WL_ROUTES: IntakeRouteSpecification = {
     },
 };
 
+export const GLOBAL_WL_LONG_ROUTES: IntakeRouteSpecification = {
+    1: {
+        version: 1,
+        route_array: [
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_INTRO,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_GOAL_WEIGHT,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_INTERACTIVE,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_MEDICATIONS,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_CHECKOUT,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_UP_NEXT,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_ORDER_SUMMARY,
+            INTAKE_ROUTE_V3.GLOBAL_WL_LONG_WHATS_NEXT,
+        ],
+        ab_tests: [],
+    },
+};
+
 export const SKINCARE_INTAKE_ROUTES: IntakeRouteSpecification = {
     1: {
         version: 1,
@@ -1171,6 +1188,10 @@ export const LATEST_INTAKE_VERSIONS: LatestIntakeSpecification = {
         latest_version: 2,
     },
     global_wl: { route_array: GLOBAL_WL_ROUTES, latest_version: 1 },
+    global_wl_long: {
+        route_array: GLOBAL_WL_LONG_ROUTES,
+        latest_version: 1,
+    },
     semaglutide: { route_array: SEMAGLUTIDE_ROUTES, latest_version: 1 },
     tirzepatide: { route_array: TIRZEPATIDE_ROUTES, latest_version: 1 },
     metformin: { route_array: METFORMIN_INTAKE_ROUTES, latest_version: 1 },

--- a/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
+++ b/bioverse-client/app/components/intake-v2/types/intake-enumerators.ts
@@ -225,4 +225,12 @@ export enum INTAKE_ROUTE_V3 {
     GLOBAL_WL_UP_NEXT = 'global-wl-up-next',
     GLOBAL_WL_ORDER_SUMMARY = 'global-wl-order-summary',
     GLOBAL_WL_WHATS_NEXT = 'global-wl-whats-next',
+    GLOBAL_WL_LONG_INTRO = 'global-wl-long-intro',
+    GLOBAL_WL_LONG_GOAL_WEIGHT = 'global-wl-long-goal-weight',
+    GLOBAL_WL_LONG_INTERACTIVE = 'global-wl-long-interactive',
+    GLOBAL_WL_LONG_MEDICATIONS = 'global-wl-long-medications',
+    GLOBAL_WL_LONG_CHECKOUT = 'global-wl-long-checkout',
+    GLOBAL_WL_LONG_UP_NEXT = 'global-wl-long-up-next',
+    GLOBAL_WL_LONG_ORDER_SUMMARY = 'global-wl-long-order-summary',
+    GLOBAL_WL_LONG_WHATS_NEXT = 'global-wl-long-whats-next',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@rudderstack/rudder-sdk-node": "^2.1.4",
+        "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.38.3",
         "@types/express": "^5.0.3",
         "@types/node": "^22.15.30",
@@ -26,6 +27,7 @@
         "@types/next": "^8.0.7",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.7",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.1",
         "next": "^15.3.3",
@@ -2274,6 +2276,27 @@
         "@types/phoenix": "^1.6.6",
         "@types/ws": "^8.18.1",
         "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+      "integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
+    "node_modules/@supabase/ssr/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -4897,6 +4920,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5083,6 +5113,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@rudderstack/rudder-sdk-node": "^2.1.4",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.38.3",
     "@types/express": "^5.0.3",
     "@types/node": "^22.15.30",
@@ -28,6 +29,7 @@
     "@types/next": "^8.0.7",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.7",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^29.6.1",
     "next": "^15.3.3",
@@ -43,7 +45,9 @@
       "./jest.setup.js"
     ],
     "moduleNameMapper": {
-      "^@/(.*)$": "<rootDir>/bioverse-client/$1"
+      "^@/(.*)$": "<rootDir>/bioverse-client/$1",
+      "^.+\\.module\\.css$": "identity-obj-proxy",
+      "^.+\\.css$": "identity-obj-proxy"
     }
   }
 }

--- a/providers/__tests__/StripeProvider.test.tsx
+++ b/providers/__tests__/StripeProvider.test.tsx
@@ -130,11 +130,11 @@ describe('StripeProvider', () => {
   it('throws when using test key in production', async () => {
     const origEnv = process.env.NODE_ENV
     const origKey = process.env.STRIPE_SK
-    process.env.NODE_ENV = 'production'
-    process.env.STRIPE_SK = 'sk_test_bad'
+    ;(process.env as any).NODE_ENV = 'production'
+    ;(process.env as any).STRIPE_SK = 'sk_test_bad'
     await expect(createCustomer()).rejects.toThrow('STRIPE_SK must be a live key in production')
-    process.env.NODE_ENV = origEnv
-    process.env.STRIPE_SK = origKey
+    ;(process.env as any).NODE_ENV = origEnv
+    ;(process.env as any).STRIPE_SK = origKey
   })
 
   it('throws when initializing StripeProvider with a test key in production', async () => {
@@ -143,13 +143,13 @@ describe('StripeProvider', () => {
     const origKey = process.env.STRIPE_SK
     const origWindow = (global as any).window
     delete (global as any).window
-    process.env.NODE_ENV = 'production'
-    process.env.STRIPE_SK = 'sk_test_bad'
+    ;(process.env as any).NODE_ENV = 'production'
+    ;(process.env as any).STRIPE_SK = 'sk_test_bad'
     await expect(
       StripeProvider({ children: React.createElement('div') })
     ).rejects.toThrow('STRIPE_SK must be a live key in production')
-    process.env.NODE_ENV = origEnv
-    process.env.STRIPE_SK = origKey
+    ;(process.env as any).NODE_ENV = origEnv
+    ;(process.env as any).STRIPE_SK = origKey
     if (origWindow !== undefined) (global as any).window = origWindow
   })
 


### PR DESCRIPTION
## Summary
- extend intake enumerators with `GLOBAL_WL_LONG_*` routes
- define `GLOBAL_WL_LONG_ROUTES` and add to latest intake versions
- scaffold new `global-wl-long-*` pages for each product
- adjust related tests and Jest config

## Testing
- `npm test` *(fails: Cannot find module 'stripe' in medication endpoints test)*

------
https://chatgpt.com/codex/tasks/task_b_68462d5e5a3483288f0080a9f35ad4fb