### PR TITLE
Add B12 API flow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 - [Dashboard Guide](docs/dashboard-guide.md)
 - [Stripe API Reference](docs/stripe)
 - [Stripe Request Examples](docs/stripe/examples.md)
+- [Global Weight Loss Funnel Plan](docs/global-wl-plan.md)
+- [B12 Injection API Flow](docs/b12-injection-flow.md)
 
 ## SupabaseProvider
 

--- a/docs/b12-injection-flow.md
+++ b/docs/b12-injection-flow.md
@@ -1,0 +1,26 @@
+# B12 Injection Intake Flow – API Reference
+
+This document details the network calls and data sources used in each step of the B12 injection intake funnel. It is based on the implementation under `bioverse-client/app/(intake)/intake/prescriptions/[product]`.
+
+| Page | API Calls | Databases/Tables | Analytics |
+| --- | --- | --- | --- |
+| `improve-function` | `readUserSession()` | `auth.sessions` via Supabase | – |
+| `b12-advantages` | none | – | – |
+| `registration` | `readUserSession()`, Supabase auth session | `auth.sessions` | – |
+| `state-selection` | `readUserSession()`, `getUserState()` | `profiles.state` | – |
+| `date-of-birth` | `readUserSession()`, `getUserDateOfBirth()` | `profiles.date_of_birth` | – |
+| `good-news-v3` | `readUserSession()`, `getCustomerFirstNameById()` | `profiles.first_name` | – |
+| `demographic-collection` | `readUserSession()`, `getIntakeProfileData()`, `getPriceVariantTableData()` | `profiles`, `product_variants` | – |
+| `greeting` | `readUserSession()`, `getCustomerFirstNameById()` | `profiles.first_name` | – |
+| `up-next` | `readUserSession()` | `auth.sessions` | – |
+| `questions` | `getQuestionsForProduct_with_Version()` | RPC `get_questions_for_product_with_version` | – |
+| `questions/[question_id]` | `readUserSession()`, `getAccountProfileData()` | `profiles` | – |
+| `select-supply` | `readUserSession()`, `getOrderForProduct()`, `getMonthlyAndQuarterlyPriceVariantData()`, `getNonGLPDiscountForProduct()` | `orders`, `product_variants`, `discounts` | – |
+| `general-order-summary` | `readUserSession()`, `getOrderForProduct()`, `getPriceDataRecordWithVariant()` | `orders`, `product_variants` | – |
+| `b12-reviews` | none | – | – |
+| `pre-id` | `readUserSession()`, `getIDVerificationData()` | `profiles.license_photo_url`, `profiles.selfie_photo_url` | – |
+| `id-verification` | `readUserSession()`, `getIDVerificationData()` | `profiles` | – |
+| `shipping-information` | `readUserSession()`, `getShippingInformationData()` | `profiles` | – |
+| `new-checkout` | `readUserSession()`, `getFullIntakeProfileData()`, `checkForExistingOrderV2()`, `getPriceVariantTableData()`, `updateOrderDiscount()`, `fetchProductImageAndPriceData()` | `profiles`, `orders`, `product_variants`, `products`, `stripe_product_coupon_pairs` | `trackRudderstackEvent('ORDER_RECEIVED')` upon completion |
+
+The functions above ultimately call the Supabase client to read or write data. See the `call-graph.json` call chart and `migration-plan.json` for the wider dependency graph and active refactor tasks.

--- a/docs/global-wl-plan.md
+++ b/docs/global-wl-plan.md
@@ -108,6 +108,24 @@ estimate work in related flows.
 | `wl-checkout` | ~0.5d |
 | `wl-order-summary` | ~0.5d |
 | `wl-whats-next` | ~0.25d |
+## Reference: B12 Injection API Flow
+
+The B12 intake funnel is the most complete implementation. See [b12-injection-flow.md](./b12-injection-flow.md) for a page-by-page list of API calls, Supabase tables and RudderStack events. The global weight loss funnel should mirror this structure.
+
+### Global WL API Flow Mapping
+
+Use the B12 table as the baseline for data access and analytics. Each new page in the global weight loss funnel should call the same helpers as its closest B12 counterpart:
+
+| Global WL Page | Mirrors B12 Page | Primary Calls |
+| --- | --- | --- |
+| `global-wl-intro` | `improve-function` | `readUserSession()` |
+| `global-wl-goal-weight` | `demographic-collection` | `readUserSession()`, `getIntakeProfileData()` |
+| `global-wl-interactive` | `questions` | `getQuestionsForProduct_with_Version()` |
+| `global-wl-medications` | `select-supply` | `getOrderForProduct()`, `getPriceVariantTableData()` |
+| `global-wl-checkout` | `new-checkout` | `getFullIntakeProfileData()`, `checkForExistingOrderV2()` |
+| `global-wl-order-summary` | `general-order-summary` | `getOrderForProduct()`, `getPriceDataRecordWithVariant()` |
+| `global-wl-whats-next` | `up-next` | `readUserSession()` |
+
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document B12 injection intake API calls
- reference this doc from the global weight loss plan
- map global weight loss pages to their B12 counterparts
- link new docs in the repo README

## Testing
- `npm run check:links` *(fails: ERR on several external links)*

------
https://chatgpt.com/codex/tasks/task_b_6846cd969f548328ac1504a4158d7659