### PR TITLE
Add Global WL affordable intro page

### DIFF
--- a/bioverse-client/__tests__/intake-v4-pages.test.tsx
+++ b/bioverse-client/__tests__/intake-v4-pages.test.tsx
@@ -1,84 +1,98 @@
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import GoalWeight from '../app/components/intake-v4/pages/goal-weight'
-import MedicationOptions from '../app/components/intake-v4/pages/medication-options'
-import GlobalIntro from '../app/components/intake-v4/pages/global-intro'
-import GlobalCheckout from '../app/components/intake-v4/pages/global-checkout'
-import GlobalOrderSummary from '../app/components/intake-v4/pages/global-order-summary'
-import GlobalWLUpNext from '../app/components/intake-v4/pages/global-up-next'
-import GlobalWhatsNext from '../app/components/intake-v4/pages/global-whats-next'
-import InteractiveBMI from '../app/components/intake-v4/pages/interactive-bmi'
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import GoalWeight from '../app/components/intake-v4/pages/goal-weight';
+import MedicationOptions from '../app/components/intake-v4/pages/medication-options';
+import GlobalIntro from '../app/components/intake-v4/pages/global-intro';
+import GlobalWLAffordableIntro from '../app/components/intake-v4/pages/global-affordable-intro';
+import GlobalCheckout from '../app/components/intake-v4/pages/global-checkout';
+import GlobalOrderSummary from '../app/components/intake-v4/pages/global-order-summary';
+import GlobalWLUpNext from '../app/components/intake-v4/pages/global-up-next';
+import GlobalWhatsNext from '../app/components/intake-v4/pages/global-whats-next';
+import InteractiveBMI from '../app/components/intake-v4/pages/interactive-bmi';
 
 jest.mock('@mui/material', () => ({
-  Button: (props: any) => <button {...props} />,
-}))
+    Button: (props: any) => <button {...props} />,
+}));
 
-const push = jest.fn()
+const push = jest.fn();
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push }),
-  useParams: () => ({ product: 'weight-loss' }),
-  useSearchParams: () => new URLSearchParams(),
-  usePathname: () => '/intake/prescriptions/weight-loss/current',
-}))
+    useRouter: () => ({ push }),
+    useParams: () => ({ product: 'weight-loss' }),
+    useSearchParams: () => new URLSearchParams(),
+    usePathname: () => '/intake/prescriptions/weight-loss/current',
+}));
 
 jest.mock('../app/components/intake-v2/intake-functions', () => ({
-  getIntakeURLParams: () => ({ product_href: 'weight-loss' }),
-}))
+    getIntakeURLParams: () => ({ product_href: 'weight-loss' }),
+}));
 
 jest.mock('../app/utils/functions/intake-route-controller', () => ({
-  getNextIntakeRoute: () => 'next'
-}))
+    getNextIntakeRoute: () => 'next',
+}));
 
-global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true, medications: [] }) })
+global.fetch = jest
+    .fn()
+    .mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, medications: [] }),
+    });
 
 describe('intake v4 pages', () => {
-  afterEach(() => { push.mockClear() })
+    afterEach(() => {
+        push.mockClear();
+    });
 
-  it('goal weight navigates on continue', () => {
-    const { getByText } = render(<GoalWeight userId="123" />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('goal weight navigates on continue', () => {
+        const { getByText } = render(<GoalWeight userId="123" />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('medication options navigates on continue', () => {
-    const { getByText } = render(<MedicationOptions userId="123" />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('medication options navigates on continue', () => {
+        const { getByText } = render(<MedicationOptions userId="123" />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('interactive BMI navigates on continue', () => {
-    const { getByText } = render(<InteractiveBMI userId="123" />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('interactive BMI navigates on continue', () => {
+        const { getByText } = render(<InteractiveBMI userId="123" />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('global intro navigates on continue', () => {
-    const { getByText } = render(<GlobalIntro />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('global intro navigates on continue', () => {
+        const { getByText } = render(<GlobalIntro />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('global checkout navigates on continue', () => {
-    const { getByText } = render(<GlobalCheckout />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('affordable intro navigates on continue', () => {
+        const { getByText } = render(<GlobalWLAffordableIntro />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('global order summary navigates on continue', () => {
-    const { getByText } = render(<GlobalOrderSummary />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('global checkout navigates on continue', () => {
+        const { getByText } = render(<GlobalCheckout />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('global up next navigates on continue', () => {
-    const { getByText } = render(<GlobalWLUpNext />)
-    fireEvent.click(getByText('Continue'))
-    expect(push).toHaveBeenCalled()
-  })
+    it('global order summary navigates on continue', () => {
+        const { getByText } = render(<GlobalOrderSummary />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
 
-  it('global whats next renders text', () => {
-    const { getByText } = render(<GlobalWhatsNext />)
-    expect(getByText("What's Next")).toBeTruthy()
-  })
-})
+    it('global up next navigates on continue', () => {
+        const { getByText } = render(<GlobalWLUpNext />);
+        fireEvent.click(getByText('Continue'));
+        expect(push).toHaveBeenCalled();
+    });
+
+    it('global whats next renders text', () => {
+        const { getByText } = render(<GlobalWhatsNext />);
+        expect(getByText("What's Next")).toBeTruthy();
+    });
+});

--- a/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-affordable-intro/page.tsx
+++ b/bioverse-client/app/(intake)/intake/prescriptions/[product]/global-wl-affordable-intro/page.tsx
@@ -1,0 +1,21 @@
+'use server';
+
+import GlobalWLAffordableIntro from '@/app/components/intake-v4/pages/global-affordable-intro';
+import { readUserSession } from '@/app/utils/actions/auth/session-reader';
+
+interface Props {
+    params: { product: string };
+    searchParams: { pvn: any; st: any; psn: any; sd: any; ub: any };
+}
+
+export default async function GlobalWLAffordableIntroPage({
+    params,
+    searchParams,
+}: Props) {
+    const user_id = (await readUserSession()).data.session?.user.id!;
+    return (
+        <>
+            <GlobalWLAffordableIntro />
+        </>
+    );
+}

--- a/bioverse-client/app/components/intake-v4/pages/global-affordable-intro.tsx
+++ b/bioverse-client/app/components/intake-v4/pages/global-affordable-intro.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import Image from 'next/image';
+import {
+    useParams,
+    usePathname,
+    useRouter,
+    useSearchParams,
+} from 'next/navigation';
+import { useState } from 'react';
+import AnimatedContinueButtonV3 from '@/app/components/intake-v3/buttons/AnimatedContinueButtonV3';
+import BioType from '@/app/components/global-components/bioverse-typography/bio-type/bio-type';
+import { getIntakeURLParams } from '@/app/components/intake-v2/intake-functions';
+import { getNextIntakeRoute } from '@/app/utils/functions/intake-route-controller';
+
+export default function GlobalWLAffordableIntro() {
+    const router = useRouter();
+    const url = useParams();
+    const searchParams = useSearchParams();
+    const search = searchParams.toString();
+    const fullPath = usePathname();
+    const { product_href } = getIntakeURLParams(url, searchParams);
+    const [loading, setLoading] = useState(false);
+
+    const pushToNextRoute = () => {
+        setLoading(true);
+        const nextRoute = getNextIntakeRoute(fullPath, product_href, search);
+        router.push(
+            `/intake/prescriptions/${product_href}/${nextRoute}?${search}`,
+        );
+    };
+
+    return (
+        <div className="flex justify-center mt-[1.25rem] md:mt-12 w-full">
+            <div className="flex flex-col gap-8 w-full max-w-[22.5rem] md:max-w-[390px]">
+                <div className="flex flex-col gap-6">
+                    <BioType className="inter-h5-question-header">
+                        Affordable treatments, for every body.
+                    </BioType>
+                    <div className="grid grid-cols-2 gap-4">
+                        <Image
+                            src="https://via.placeholder.com/150"
+                            alt="option 1"
+                            width={200}
+                            height={200}
+                            className="rounded-lg"
+                        />
+                        <Image
+                            src="https://via.placeholder.com/150"
+                            alt="option 2"
+                            width={200}
+                            height={200}
+                            className="rounded-lg"
+                        />
+                        <Image
+                            src="https://via.placeholder.com/150"
+                            alt="option 3"
+                            width={200}
+                            height={200}
+                            className="rounded-lg"
+                        />
+                        <Image
+                            src="https://via.placeholder.com/150"
+                            alt="option 4"
+                            width={200}
+                            height={200}
+                            className="rounded-lg"
+                        />
+                    </div>
+                    <BioType className="text-sm text-gray-600">
+                        Access a range of treatment options, from compounded
+                        semaglutide to brand name GLP-1 injections if you
+                        qualify.
+                    </BioType>
+                </div>
+                <AnimatedContinueButtonV3 onClick={pushToNextRoute} />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- introduce `global-affordable-intro` page component for the global weight loss flow
- add server route to render it under `global-wl-affordable-intro`
- test that the new page navigates on continue

## Testing
- `npm test` *(fails: stripe API type errors)*

------
https://chatgpt.com/codex/tasks/task_b_6846f9d87b508328b1bdb8806c881509